### PR TITLE
fix scope omp setter

### DIFF
--- a/src/knowhere/thread_pool.cc
+++ b/src/knowhere/thread_pool.cc
@@ -172,12 +172,12 @@ ThreadPool::GetGlobalFetchThreadPool() {
 
 ThreadPool::ScopedBuildOmpSetter::ScopedBuildOmpSetter(int num_threads) {
     omp_before = (build_pool_ ? build_pool_->size() : omp_get_max_threads());
+    omp_set_num_threads(num_threads <= 0 ? omp_before : num_threads);
 #ifdef OPENBLAS_OS_LINUX
     // to avoid thread spawn when IVF_PQ build
-    blas_thread_before = openblas_get_num_threads();
-    openblas_set_num_threads(1);
+    blas_thread_before = (build_pool_ ? build_pool_->size() : openblas_get_num_threads());
+    openblas_set_num_threads(num_threads <= 0 ? blas_thread_before : num_threads);
 #endif
-    omp_set_num_threads(num_threads <= 0 ? omp_before : num_threads);
 }
 
 ThreadPool::ScopedBuildOmpSetter::~ScopedBuildOmpSetter() {
@@ -191,16 +191,16 @@ ThreadPool::ScopedSearchOmpSetter::ScopedSearchOmpSetter(int num_threads) {
     omp_before = (search_pool_ ? search_pool_->size() : omp_get_max_threads());
     omp_set_num_threads(num_threads <= 0 ? omp_before : num_threads);
 #ifdef OPENBLAS_OS_LINUX
-    blas_thread_before = openblas_get_num_threads();
+    blas_thread_before = (search_pool_ ? search_pool_->size() : openblas_get_num_threads());
     openblas_set_num_threads(num_threads <= 0 ? blas_thread_before : num_threads);
 #endif
 }
 
 ThreadPool::ScopedSearchOmpSetter::~ScopedSearchOmpSetter() {
-    omp_set_num_threads(omp_before);
 #ifdef OPENBLAS_OS_LINUX
     openblas_set_num_threads(blas_thread_before);
 #endif
+    omp_set_num_threads(omp_before);
 }
 
 }  // namespace knowhere


### PR DESCRIPTION
openblas_set_num_threads and omp_set_num_threads might interfere with each other. Here, we prioritize openblas_set_num_threads and handle it in a stack-based push-pop manner to ensure logical consistency.

