### PR TITLE
enhance: expose Close() method in OutputStream interface

### DIFF
--- a/include/filemanager/OutputStream.h
+++ b/include/filemanager/OutputStream.h
@@ -59,5 +59,11 @@ class OutputStream {
 
     virtual size_t
     Write(int fd, size_t size) = 0;
+
+    /**
+     * @brief close the stream
+     */
+    virtual void
+    Close() = 0;
 };
 }  // namespace milvus

--- a/include/filemanager/impl/LocalOutputStream.h
+++ b/include/filemanager/impl/LocalOutputStream.h
@@ -26,6 +26,9 @@ class LocalOutputStream : public OutputStream {
     size_t
     Write(int fd, size_t size) override;
 
+    void
+    Close() override;
+
  private:
     mutable std::ofstream stream_;
     std::string filename_;

--- a/src/filemanager/impl/LocalOutputStream.cpp
+++ b/src/filemanager/impl/LocalOutputStream.cpp
@@ -29,6 +29,11 @@ LocalOutputStream::Write(const void* ptr, size_t size) {
     return size;
 }
 
+void
+LocalOutputStream::Close() {
+    stream_.close();
+}
+
 size_t
 LocalOutputStream::Write(int fd, size_t size) {
     size_t buffer_size = std::min(size, static_cast<size_t>(4096));


### PR DESCRIPTION
Add Close() virtual method to OutputStream base class and implement it in LocalOutputStream to allow callers to explicitly close the stream.