### PR TITLE
enhance: cachinglayer: add async warmup support

### DIFF
--- a/include/cachinglayer/Utils.h
+++ b/include/cachinglayer/Utils.h
@@ -230,6 +230,8 @@ struct CacheWarmupPolicies {
             switch (policy) {
                 case CacheWarmupPolicy::CacheWarmupPolicy_Sync:
                     return "Sync";
+                case CacheWarmupPolicy::CacheWarmupPolicy_Async:
+                    return "Async";
                 case CacheWarmupPolicy::CacheWarmupPolicy_Disable:
                     return "Disable";
                 default:

--- a/include/common/common_type_c.h
+++ b/include/common/common_type_c.h
@@ -23,6 +23,7 @@ typedef struct CStatus {
 enum CacheWarmupPolicy {
     CacheWarmupPolicy_Disable = 0,
     CacheWarmupPolicy_Sync = 1,
+    CacheWarmupPolicy_Async = 2,
 };
 
 typedef enum CacheWarmupPolicy CacheWarmupPolicy;


### PR DESCRIPTION
Async warmup uses a shared CPUThreadPoolExecutor (prefetch_pool) owned by Manager. When CacheWarmupPolicy_Async is set and a pool is available, Warmup() queues the loading task and returns immediately. The task captures a weak_ptr<CacheSlot> to safely handle slot destruction while warmup is pending - if the slot is destroyed before the task runs, the weak_ptr::lock() fails and warmup is skipped.

- Non-blocking warmup - callers don't wait for I/O
- Graceful degradation - falls back to sync if no pool provided
- Safe lifetime management via weak_ptr prevents use-after-free
- Shared thread pool avoids thread explosion across many CacheSlots
- Existing cell access patterns work unchanged (block on SharedPromise)

Note:

- First access still blocks if warmup hasn't completed yet
- No completion callback - callers can't know when warmup finishes
- Warmup failures are only logged, no retry or notification mechanism
- ctx not captured in async path - storage usage not tracked for warmup