### PR TITLE
fix: add early return in tracer when tracing is disabled

### DIFF
--- a/include/common/Tracer.h
+++ b/include/common/Tracer.h
@@ -44,6 +44,9 @@ namespace trace = opentelemetry::trace;
 void
 initTelemetry(const TraceConfig& cfg);
 
+bool
+IsTraceEnabled();
+
 std::shared_ptr<trace::Tracer>
 GetTracer();
 


### PR DESCRIPTION
When tracing is disabled (noop mode), the tracer was still acquiring
SpinLockMutex and creating shared_ptr spans, causing significant CPU
overhead.

Changes:
- Add IsTraceEnabled() helper function
- Add static noop_span for safe returns when tracing disabled
- Add early return in StartSpan() functions, returning noop_span
- Add early return in AutoSpan constructors when tracing disabled
- AutoSpan::GetSpan() returns noop_span if span_ is nullptr
- Add comprehensive tests for disabled tracing behavior

This eliminates lock contention and dynamic allocation while maintaining
backward compatibility - all existing code using span->Method() works
safely without modification.