### PR TITLE
fix: integrate LoadingOverheadTracker into DList to eliminate TOCTOU

### DIFF
--- a/include/cachinglayer/CacheSlot.h
+++ b/include/cachinglayer/CacheSlot.h
@@ -58,7 +58,7 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
     CacheSlot(std::unique_ptr<Translator<CellT>> translator, internal::DList* dlist, bool evictable, bool self_reserve,
               bool storage_usage_tracking_enabled, std::chrono::milliseconds loading_timeout,
               std::chrono::milliseconds warmup_loading_timeout,
-              LoadingOverheadTracker* loading_overhead_tracker = nullptr)
+              uint64_t overhead_handle = 0)
         : translator_(std::move(translator)),
           cell_id_mapping_mode_(translator_->meta()->cell_id_mapping_mode),
           cell_data_type_(translator_->meta()->cell_data_type),
@@ -69,7 +69,7 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
           storage_usage_tracking_enabled_(storage_usage_tracking_enabled),
           loading_timeout_(loading_timeout),
           warmup_loading_timeout_(warmup_loading_timeout),
-          loading_overhead_tracker_(loading_overhead_tracker) {
+          overhead_handle_(overhead_handle) {
         cells_.reserve(translator_->num_cells());
         for (cid_t i = 0; i < static_cast<cid_t>(translator_->num_cells()); ++i) {
             cells_.push_back(std::make_unique<CacheCell>(this, i));
@@ -466,35 +466,12 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
             auto loaded_resource = essential_loaded_resource + bonus_loaded_resource;
             auto loading_overhead = essential_loading_overhead + bonus_loading_overhead;
 
-            // Reserve tracker + DList atomically. On success, returns a guard that
-            // releases both on destruction. On failure, tracker state is rolled back
-            // before returning. No resource is left dangling in either case.
-            auto try_reserve = [this](const ResourceUsage& loaded, const ResourceUsage& loading,
-                                      std::chrono::milliseconds timeout,
-                                      OpContext* ctx) -> std::pair<bool, ResourceUsage /*actual_dlist_reserve*/> {
-                auto loading_delta = loading;
-                if (loading_overhead_tracker_) {
-                    loading_delta = loading_overhead_tracker_->Reserve(cell_data_type_, loading);
-                }
-                auto actual_dlist_reserve = loaded + loading_delta;
+            auto actual_dlist_reserve = SemiInlineGet(dlist_->ReserveLoadingResourceWithTimeout(
+                loaded_resource, loading_overhead, overhead_handle_, timeout, ctx));
+            bool reservation_success = actual_dlist_reserve.AnyGTZero();
 
-                bool success =
-                    SemiInlineGet(dlist_->ReserveLoadingResourceWithTimeout(actual_dlist_reserve, timeout, ctx));
-                if (!success) {
-                    if (loading_overhead_tracker_) {
-                        loading_overhead_tracker_->Release(cell_data_type_, loading);
-                    }
-                    return {false, {}};
-                }
-                return {true, actual_dlist_reserve};
-            };
-
-            auto reserve_result = try_reserve(loaded_resource, loading_overhead, timeout, ctx);
-            bool reservation_success = reserve_result.first;
-            ResourceUsage actual_dlist_reserve = reserve_result.second;
-
-            // Guard created immediately after reserve — all by-ref so bonus retry
-            // and metrics setup are automatically reflected. No gap, no handoff.
+            // Guard: releases DList + tracker atomically. All by-ref so bonus retry
+            // updates are reflected automatically.
             bool metrics_tracked = false;
             size_t loading_cids_count = 0;
             auto defer_release = folly::makeGuard([&]() {
@@ -502,18 +479,14 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
                     return;
                 }
                 try {
-                    auto release_delta = loading_overhead;
-                    if (loading_overhead_tracker_) {
-                        release_delta = loading_overhead_tracker_->Release(cell_data_type_, loading_overhead);
-                    }
-                    auto dlist_release = loaded_resource + release_delta;
-                    dlist_->ReleaseLoadingResource(dlist_release);
+                    dlist_->ReleaseLoadingResource(loaded_resource, loading_overhead,
+                                                   overhead_handle_);
                     if (metrics_tracked) {
                         monitor::cache_cell_loading_count(cell_data_type_, storage_type_).Decrement(loading_cids_count);
                         monitor::cache_loading_bytes(cell_data_type_, StorageType::MEMORY)
-                            .Decrement(dlist_release.memory_bytes);
+                            .Decrement(actual_dlist_reserve.memory_bytes);
                         monitor::cache_loading_bytes(cell_data_type_, StorageType::DISK)
-                            .Decrement(dlist_release.file_bytes);
+                            .Decrement(actual_dlist_reserve.file_bytes);
                     }
                 } catch (...) {
                     auto ew = folly::exception_wrapper(std::current_exception());
@@ -532,9 +505,9 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
                         "essential loading resource");
                     loaded_resource = essential_loaded_resource;
                     loading_overhead = essential_loading_overhead;
-                    auto retry = try_reserve(loaded_resource, loading_overhead, timeout, ctx);
-                    reservation_success = retry.first;
-                    actual_dlist_reserve = retry.second;
+                    actual_dlist_reserve = SemiInlineGet(dlist_->ReserveLoadingResourceWithTimeout(
+                        loaded_resource, loading_overhead, overhead_handle_, timeout, ctx));
+                    reservation_success = actual_dlist_reserve.AnyGTZero();
                 } else {
                     loading_cids.insert(loading_cids.end(), bonus_cids.begin(), bonus_cids.end());
                 }
@@ -705,7 +678,7 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
     const bool storage_usage_tracking_enabled_;
     std::chrono::milliseconds loading_timeout_{100000};
     std::chrono::milliseconds warmup_loading_timeout_{0};
-    LoadingOverheadTracker* loading_overhead_tracker_{nullptr};
+    uint64_t overhead_handle_{0};
     std::atomic<bool> warmup_called_{false};
     std::atomic<bool> skip_pin_{false};
 };

--- a/include/cachinglayer/CacheSlot.h
+++ b/include/cachinglayer/CacheSlot.h
@@ -57,7 +57,7 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
 
     CacheSlot(std::unique_ptr<Translator<CellT>> translator, internal::DList* dlist, bool evictable, bool self_reserve,
               bool storage_usage_tracking_enabled, std::chrono::milliseconds loading_timeout,
-              std::chrono::milliseconds warmup_loading_timeout, uint64_t overhead_handle = 0)
+              std::chrono::milliseconds warmup_loading_timeout)
         : translator_(std::move(translator)),
           cell_id_mapping_mode_(translator_->meta()->cell_id_mapping_mode),
           cell_data_type_(translator_->meta()->cell_data_type),
@@ -67,8 +67,10 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
           self_reserve_(self_reserve),
           storage_usage_tracking_enabled_(storage_usage_tracking_enabled),
           loading_timeout_(loading_timeout),
-          warmup_loading_timeout_(warmup_loading_timeout),
-          overhead_handle_(overhead_handle) {
+          warmup_loading_timeout_(warmup_loading_timeout) {
+        if (auto& lo = translator_->meta()->loading_overhead) {
+            overhead_handle_ = dlist_->RegisterLoadingOverhead(lo->group, lo->upper_bound);
+        }
         cells_.reserve(translator_->num_cells());
         for (cid_t i = 0; i < static_cast<cid_t>(translator_->num_cells()); ++i) {
             cells_.push_back(std::make_unique<CacheCell>(this, i));
@@ -323,6 +325,7 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
     }
 
     ~CacheSlot() {
+        dlist_->UnregisterLoadingOverhead(overhead_handle_);
         monitor::cache_slot_count(cell_data_type_, storage_type_).Decrement();
         monitor::cache_cell_count(cell_data_type_, storage_type_).Decrement(translator_->num_cells());
     }
@@ -465,8 +468,12 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
             auto loaded_resource = essential_loaded_resource + bonus_loaded_resource;
             auto loading_overhead = essential_loading_overhead + bonus_loading_overhead;
 
+            // When bonus cells are present, first try best-effort (timeout=0) for essential+bonus.
+            // If that fails, fall back to essential-only with the real timeout.
+            // This avoids blocking in the waiting queue for a bonus attempt that could retry immediately.
+            auto reserve_timeout = bonus_cids.empty() ? timeout : std::chrono::milliseconds(0);
             auto actual_dlist_reserve = SemiInlineGet(dlist_->ReserveLoadingResourceWithTimeout(
-                loaded_resource, loading_overhead, overhead_handle_, timeout, ctx));
+                loaded_resource, loading_overhead, overhead_handle_, reserve_timeout, ctx));
             bool reservation_success = actual_dlist_reserve.AnyGTZero();
 
             // Guard: releases DList + tracker atomically. All by-ref so bonus retry
@@ -497,7 +504,7 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
 
             if (!bonus_cids.empty()) {
                 if (!reservation_success) {
-                    // Bonus+essential failed — retry with essential only
+                    // Bonus+essential failed immediately — retry with essential only using real timeout.
                     LOG_WARN(
                         "[MCL] CacheSlot reserve loading resource with bonus cells failed, try to reserve only "
                         "essential loading resource");

--- a/include/cachinglayer/CacheSlot.h
+++ b/include/cachinglayer/CacheSlot.h
@@ -470,6 +470,13 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
             auto loaded_resource = essential_loaded_resource + bonus_loaded_resource;
             auto loading_overhead = essential_loading_overhead + bonus_loading_overhead;
 
+            // Zero-resource cells: skip DList reservation entirely and load directly.
+            // set_cell() will ChargeLoadedResource with the actual size after loading.
+            if (!loaded_resource.AnyGTZero() && !loading_overhead.AnyGTZero()) {
+                run_load_internal();
+                return;
+            }
+
             // When bonus cells are present, first try best-effort (timeout=0) for essential+bonus.
             // If that fails, fall back to essential-only with the real timeout.
             // This avoids blocking in the waiting queue for a bonus attempt that could retry immediately.

--- a/include/cachinglayer/CacheSlot.h
+++ b/include/cachinglayer/CacheSlot.h
@@ -68,15 +68,17 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
           storage_usage_tracking_enabled_(storage_usage_tracking_enabled),
           loading_timeout_(loading_timeout),
           warmup_loading_timeout_(warmup_loading_timeout) {
-        if (auto& lo = translator_->meta()->loading_overhead) {
-            overhead_handle_ = dlist_->RegisterLoadingOverhead(lo->group, lo->upper_bound);
-        }
         cells_.reserve(translator_->num_cells());
         for (cid_t i = 0; i < static_cast<cid_t>(translator_->num_cells()); ++i) {
             cells_.push_back(std::make_unique<CacheCell>(this, i));
         }
         monitor::cache_slot_count(cell_data_type_, storage_type_).Increment();
         monitor::cache_cell_count(cell_data_type_, storage_type_).Increment(translator_->num_cells());
+        // Register after all potentially-throwing operations, so that if the constructor
+        // fails, we don't leak a ref_count (destructor won't run for incomplete objects).
+        if (auto& lo = translator_->meta()->loading_overhead) {
+            overhead_handle_ = dlist_->RegisterLoadingOverhead(lo->group, lo->upper_bound);
+        }
     }
 
     CacheSlot(const CacheSlot&) = delete;
@@ -485,13 +487,14 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
                     return;
                 }
                 try {
-                    dlist_->ReleaseLoadingResource(loaded_resource, loading_overhead, overhead_handle_);
+                    auto released_resource =
+                        dlist_->ReleaseLoadingResource(loaded_resource, loading_overhead, overhead_handle_);
                     if (metrics_tracked) {
                         monitor::cache_cell_loading_count(cell_data_type_, storage_type_).Decrement(loading_cids_count);
                         monitor::cache_loading_bytes(cell_data_type_, StorageType::MEMORY)
-                            .Decrement(actual_dlist_reserve.memory_bytes);
+                            .Decrement(released_resource.memory_bytes);
                         monitor::cache_loading_bytes(cell_data_type_, StorageType::DISK)
-                            .Decrement(actual_dlist_reserve.file_bytes);
+                            .Decrement(released_resource.file_bytes);
                     }
                 } catch (...) {
                     auto ew = folly::exception_wrapper(std::current_exception());

--- a/include/cachinglayer/CacheSlot.h
+++ b/include/cachinglayer/CacheSlot.h
@@ -57,8 +57,7 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
 
     CacheSlot(std::unique_ptr<Translator<CellT>> translator, internal::DList* dlist, bool evictable, bool self_reserve,
               bool storage_usage_tracking_enabled, std::chrono::milliseconds loading_timeout,
-              std::chrono::milliseconds warmup_loading_timeout,
-              uint64_t overhead_handle = 0)
+              std::chrono::milliseconds warmup_loading_timeout, uint64_t overhead_handle = 0)
         : translator_(std::move(translator)),
           cell_id_mapping_mode_(translator_->meta()->cell_id_mapping_mode),
           cell_data_type_(translator_->meta()->cell_data_type),
@@ -479,8 +478,7 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
                     return;
                 }
                 try {
-                    dlist_->ReleaseLoadingResource(loaded_resource, loading_overhead,
-                                                   overhead_handle_);
+                    dlist_->ReleaseLoadingResource(loaded_resource, loading_overhead, overhead_handle_);
                     if (metrics_tracked) {
                         monitor::cache_cell_loading_count(cell_data_type_, storage_type_).Decrement(loading_cids_count);
                         monitor::cache_loading_bytes(cell_data_type_, StorageType::MEMORY)

--- a/include/cachinglayer/LoadingOverheadTracker.h
+++ b/include/cachinglayer/LoadingOverheadTracker.h
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <mutex>
+#include <string>
 #include <unordered_map>
 
 #include "cachinglayer/Utils.h"
@@ -20,87 +21,102 @@
 
 namespace milvus::cachinglayer {
 
-// Manages per-CellDataType loading overhead reservation with an overhead upper bound (UB).
+// Manages per-group loading overhead reservation with an overhead upper bound (UB).
 //
-// The total loading overhead reserved from DList for a given type is capped at UB:
+// Groups are identified by string keys at registration time. Registration returns
+// a uint64_t handle for O(1) lookup on the hot path (Reserve/Release).
+//
+// The total loading overhead reserved from DList for a given group is capped at UB:
 //   DList loading overhead reservation = min(sum_of_overhead, UB)
 //
 // Each Reserve/Release call returns the incremental delta to apply to DList.
-// The tracker directly tracks `overhead_reserved` (actual amount of overhead currently reserved in DList) to ensure
-// correctness even when UB changes at runtime.
+// The tracker directly tracks `overhead_reserved` (actual amount of overhead currently
+// reserved in DList) to ensure correctness.
 //
-// The total DList resource reservation across all requests of a type = sum(loaded_i) + min(sum(overhead_i), UB),
-// which does not inflate with the number of queuing requests.
-//
-// By default, types are registered with kUnlimited UB, preserving original behavior (no capping).
+// By default, groups are registered with kUnlimited UB, preserving original behavior.
 class LoadingOverheadTracker {
  public:
     static inline const ResourceUsage kUnlimited{std::numeric_limits<int64_t>::max(),
                                                  std::numeric_limits<int64_t>::max()};
 
-    // Register the upper bound for a given CellDataType.
-    // If already registered with a finite UB, uses the larger of the two UBs per dimension.
-    // If previously registered with kUnlimited (default), replaces with the given UB.
-    void
-    RegisterUpperBound(CellDataType type, const ResourceUsage& upper_bound) {
+    static constexpr uint64_t kInvalidHandle = 0;
+
+    // Register a group with an upper bound. Returns a handle for hot-path use.
+    // If the group already exists with a finite UB, takes the larger of the two per dimension.
+    // If previously registered with kUnlimited, replaces with the given UB.
+    uint64_t
+    Register(const std::string& group, const ResourceUsage& upper_bound) {
         std::lock_guard<std::mutex> lock(mtx_);
-        auto [it, inserted] = type_state_.try_emplace(type, TypeState{upper_bound, {}, {}});
-        if (!inserted) {
-            auto& existing = it->second.upper_bound;
+        auto it = name_to_handle_.find(group);
+        if (it != name_to_handle_.end()) {
+            auto& existing = handle_state_[it->second].upper_bound;
             if (existing == kUnlimited) {
                 existing = upper_bound;
             } else {
                 existing.memory_bytes = std::max(existing.memory_bytes, upper_bound.memory_bytes);
                 existing.file_bytes = std::max(existing.file_bytes, upper_bound.file_bytes);
             }
+            LOG_INFO("[MCL] LoadingOverheadTracker updated UB for group '{}' (handle {}): {}", group, it->second,
+                     upper_bound.ToString());
+            return it->second;
         }
-        LOG_INFO("[MCL] LoadingOverheadTracker registered UB for type {}: {}", static_cast<int>(type),
+        auto handle = next_handle_++;
+        name_to_handle_[group] = handle;
+        handle_state_[handle] = GroupState{upper_bound, {}, {}};
+        LOG_INFO("[MCL] LoadingOverheadTracker registered group '{}' (handle {}): UB={}", group, handle,
                  upper_bound.ToString());
+        return handle;
     }
 
-    // Ensure a type is registered. If not yet registered, registers with kUnlimited.
-    void
-    EnsureRegistered(CellDataType type) {
+    // Ensure a group is registered. If not yet registered, registers with kUnlimited.
+    uint64_t
+    EnsureRegistered(const std::string& group) {
         std::lock_guard<std::mutex> lock(mtx_);
-        type_state_.try_emplace(type, TypeState{kUnlimited, {}, {}});
+        auto it = name_to_handle_.find(group);
+        if (it != name_to_handle_.end()) {
+            return it->second;
+        }
+        auto handle = next_handle_++;
+        name_to_handle_[group] = handle;
+        handle_state_[handle] = GroupState{kUnlimited, {}, {}};
+        return handle;
     }
 
     // Called before loading. Returns the delta to reserve from DList for loading overhead.
-    // Caller should: DList.Reserve(loaded_resource + delta)
     ResourceUsage
-    Reserve(CellDataType type, const ResourceUsage& loading_overhead) {
+    Reserve(uint64_t handle, const ResourceUsage& loading_overhead) {
         std::lock_guard<std::mutex> lock(mtx_);
-        auto& state = getOrCreateState(type);
+        auto it = handle_state_.find(handle);
+        if (it == handle_state_.end()) {
+            return loading_overhead;
+        }
+        auto& state = it->second;
         state.sum_of_overhead += loading_overhead;
         auto target = cappedAmount(state.sum_of_overhead, state.upper_bound);
         auto delta = target - state.overhead_reserved;
         delta.memory_bytes = std::max(delta.memory_bytes, int64_t{0});
         delta.file_bytes = std::max(delta.file_bytes, int64_t{0});
         state.overhead_reserved += delta;
-        LOG_TRACE(
-            "[MCL] LoadingOverheadTracker Reserve type={}: loading={}, "
-            "sum={}, UB={}, overhead_reserved={}, delta={}",
-            static_cast<int>(type), loading_overhead.ToString(), state.sum_of_overhead.ToString(),
-            state.upper_bound.ToString(), state.overhead_reserved.ToString(), delta.ToString());
         return delta;
     }
 
-    // Called to release a previous Reserve (either after loading completes, or to undo
-    // a Reserve when DList reservation fails / bonus cells retry).
+    // Called to release a previous Reserve.
     // Returns the delta to release from DList for loading overhead.
     ResourceUsage
-    Release(CellDataType type, const ResourceUsage& loading_overhead) {
+    Release(uint64_t handle, const ResourceUsage& loading_overhead) {
         std::lock_guard<std::mutex> lock(mtx_);
-        auto& state = getOrCreateState(type);
+        auto it = handle_state_.find(handle);
+        if (it == handle_state_.end()) {
+            return loading_overhead;
+        }
+        auto& state = it->second;
         state.sum_of_overhead -= loading_overhead;
         if (state.sum_of_overhead.memory_bytes < 0) {
-            LOG_ERROR("[MCL] LoadingOverheadTracker ReleaseInternal type={}: sum_of_overhead.memory_bytes < 0",
-                      static_cast<int>(type));
+            LOG_ERROR("[MCL] LoadingOverheadTracker Release handle {}: sum_of_overhead.memory_bytes < 0", handle);
             state.sum_of_overhead.memory_bytes = 0;
         }
         if (state.sum_of_overhead.file_bytes < 0) {
-            LOG_ERROR("[MCL] LoadingOverheadTracker ReleaseInternal type={}: sum_of_overhead.file_bytes < 0",
-                      static_cast<int>(type));
+            LOG_ERROR("[MCL] LoadingOverheadTracker Release handle {}: sum_of_overhead.file_bytes < 0", handle);
             state.sum_of_overhead.file_bytes = 0;
         }
         auto target = cappedAmount(state.sum_of_overhead, state.upper_bound);
@@ -108,38 +124,31 @@ class LoadingOverheadTracker {
         delta.memory_bytes = std::max(delta.memory_bytes, int64_t{0});
         delta.file_bytes = std::max(delta.file_bytes, int64_t{0});
         state.overhead_reserved -= delta;
-        LOG_TRACE(
-            "[MCL] LoadingOverheadTracker Release type={}: loading={}, "
-            "sum={}, UB={}, overhead_reserved={}, delta={}",
-            static_cast<int>(type), loading_overhead.ToString(), state.sum_of_overhead.ToString(),
-            state.upper_bound.ToString(), state.overhead_reserved.ToString(), delta.ToString());
         return delta;
     }
 
-    // Check if a type has a finite (non-unlimited) upper bound registered.
     bool
-    HasFiniteUpperBound(CellDataType type) const {
+    HasFiniteUpperBound(uint64_t handle) const {
         std::lock_guard<std::mutex> lock(mtx_);
-        auto it = type_state_.find(type);
-        return it != type_state_.end() && !(it->second.upper_bound == kUnlimited);
+        auto it = handle_state_.find(handle);
+        return it != handle_state_.end() && !(it->second.upper_bound == kUnlimited);
     }
 
-    // Get the upper bound for a type.
     ResourceUsage
-    GetUpperBound(CellDataType type) const {
+    GetUpperBound(uint64_t handle) const {
         std::lock_guard<std::mutex> lock(mtx_);
-        auto it = type_state_.find(type);
-        if (it == type_state_.end()) {
+        auto it = handle_state_.find(handle);
+        if (it == handle_state_.end()) {
             return kUnlimited;
         }
         return it->second.upper_bound;
     }
 
  private:
-    struct TypeState {
+    struct GroupState {
         ResourceUsage upper_bound;
-        ResourceUsage sum_of_overhead;    // total loading overhead requested (uncapped)
-        ResourceUsage overhead_reserved;  // actual amount currently reserved in DList
+        ResourceUsage sum_of_overhead;
+        ResourceUsage overhead_reserved;
     };
 
     static ResourceUsage
@@ -148,14 +157,10 @@ class LoadingOverheadTracker {
                 std::min(std::max(sum.file_bytes, int64_t{0}), ub.file_bytes)};
     }
 
-    TypeState&
-    getOrCreateState(CellDataType type) {
-        auto [it, _] = type_state_.try_emplace(type, TypeState{kUnlimited, {}, {}});
-        return it->second;
-    }
-
     mutable std::mutex mtx_;
-    std::unordered_map<CellDataType, TypeState> type_state_;
+    std::unordered_map<std::string, uint64_t> name_to_handle_;
+    std::unordered_map<uint64_t, GroupState> handle_state_;
+    uint64_t next_handle_{1};
 };
 
 }  // namespace milvus::cachinglayer

--- a/include/cachinglayer/LoadingOverheadTracker.h
+++ b/include/cachinglayer/LoadingOverheadTracker.h
@@ -44,32 +44,34 @@ class LoadingOverheadTracker {
     // Register a group with an upper bound. Returns a handle for hot-path use.
     // If the group already exists with a finite UB, takes the larger of the two per dimension.
     // If previously registered with kUnlimited, replaces with the given UB.
+    // Each Register increments a ref count; call Unregister to decrement.
     uint64_t
     Register(const std::string& group, const ResourceUsage& upper_bound) {
         std::lock_guard<std::mutex> lock(mtx_);
         auto it = name_to_handle_.find(group);
         if (it != name_to_handle_.end()) {
-            auto& existing = handle_state_[it->second].upper_bound;
-            if (existing == kUnlimited) {
-                existing = upper_bound;
-                LOG_INFO("[MCL] LoadingOverheadTracker set UB for group '{}' (handle {}): {}", group, it->second,
-                         upper_bound.ToString());
-            } else if (existing.memory_bytes < upper_bound.memory_bytes ||
-                       existing.file_bytes < upper_bound.file_bytes) {
-                existing.memory_bytes = std::max(existing.memory_bytes, upper_bound.memory_bytes);
-                existing.file_bytes = std::max(existing.file_bytes, upper_bound.file_bytes);
-                LOG_INFO("[MCL] LoadingOverheadTracker widened UB for group '{}' (handle {}): {}", group, it->second,
-                         existing.ToString());
+            auto& state = handle_state_[it->second];
+            state.ref_count++;
+            if (state.upper_bound == kUnlimited) {
+                state.upper_bound = upper_bound;
+                LOG_INFO("[MCL] LoadingOverheadTracker set UB for group '{}' (handle {}, refs={}): {}", group,
+                         it->second, state.ref_count, upper_bound.ToString());
+            } else if (state.upper_bound.memory_bytes < upper_bound.memory_bytes ||
+                       state.upper_bound.file_bytes < upper_bound.file_bytes) {
+                state.upper_bound.memory_bytes = std::max(state.upper_bound.memory_bytes, upper_bound.memory_bytes);
+                state.upper_bound.file_bytes = std::max(state.upper_bound.file_bytes, upper_bound.file_bytes);
+                LOG_INFO("[MCL] LoadingOverheadTracker widened UB for group '{}' (handle {}, refs={}): {}", group,
+                         it->second, state.ref_count, state.upper_bound.ToString());
             } else {
-                LOG_DEBUG("[MCL] LoadingOverheadTracker re-registered group '{}' (handle {}), UB unchanged", group,
-                          it->second);
+                LOG_DEBUG("[MCL] LoadingOverheadTracker re-registered group '{}' (handle {}, refs={}), UB unchanged",
+                          group, it->second, state.ref_count);
             }
             return it->second;
         }
         auto handle = next_handle_++;
         name_to_handle_[group] = handle;
-        handle_state_[handle] = GroupState{upper_bound, {}, {}};
-        LOG_INFO("[MCL] LoadingOverheadTracker registered group '{}' (handle {}): UB={}", group, handle,
+        handle_state_[handle] = GroupState{upper_bound, {}, {}, 1};
+        LOG_INFO("[MCL] LoadingOverheadTracker registered group '{}' (handle {}, refs=1): UB={}", group, handle,
                  upper_bound.ToString());
         return handle;
     }
@@ -136,11 +138,50 @@ class LoadingOverheadTracker {
         return it->second.upper_bound;
     }
 
+    // Decrement ref count for a group. When ref count reaches 0, the group is
+    // unconditionally removed. Safe to call from CacheSlot destructor.
+    void
+    Unregister(uint64_t handle) {
+        if (handle == kInvalidHandle) {
+            return;
+        }
+        std::lock_guard<std::mutex> lock(mtx_);
+        auto it = handle_state_.find(handle);
+        if (it == handle_state_.end()) {
+            return;
+        }
+        auto& state = it->second;
+        if (state.ref_count > 0) {
+            state.ref_count--;
+        }
+        if (state.ref_count > 0) {
+            LOG_DEBUG("[MCL] LoadingOverheadTracker handle {} ref_count decremented to {}", handle, state.ref_count);
+            return;
+        }
+        // ref_count == 0, unconditionally clean up.
+        // Log error if there are residual reservations — indicates a Reserve/Release pairing bug.
+        if (state.sum_of_overhead.AnyGTZero() || state.overhead_reserved.AnyGTZero()) {
+            LOG_ERROR(
+                "[MCL] LoadingOverheadTracker handle {} ref_count=0 with residual reservations: "
+                "sum_of_overhead={}, overhead_reserved={}. Cleaning up anyway to avoid leak.",
+                handle, state.sum_of_overhead.ToString(), state.overhead_reserved.ToString());
+        }
+        for (auto nit = name_to_handle_.begin(); nit != name_to_handle_.end(); ++nit) {
+            if (nit->second == handle) {
+                LOG_INFO("[MCL] LoadingOverheadTracker unregistered group '{}' (handle {})", nit->first, handle);
+                name_to_handle_.erase(nit);
+                break;
+            }
+        }
+        handle_state_.erase(it);
+    }
+
  private:
     struct GroupState {
         ResourceUsage upper_bound;
         ResourceUsage sum_of_overhead;
         ResourceUsage overhead_reserved;
+        uint64_t ref_count{0};
     };
 
     static ResourceUsage

--- a/include/cachinglayer/LoadingOverheadTracker.h
+++ b/include/cachinglayer/LoadingOverheadTracker.h
@@ -52,12 +52,18 @@ class LoadingOverheadTracker {
             auto& existing = handle_state_[it->second].upper_bound;
             if (existing == kUnlimited) {
                 existing = upper_bound;
-            } else {
+                LOG_INFO("[MCL] LoadingOverheadTracker set UB for group '{}' (handle {}): {}", group, it->second,
+                         upper_bound.ToString());
+            } else if (existing.memory_bytes < upper_bound.memory_bytes ||
+                       existing.file_bytes < upper_bound.file_bytes) {
                 existing.memory_bytes = std::max(existing.memory_bytes, upper_bound.memory_bytes);
                 existing.file_bytes = std::max(existing.file_bytes, upper_bound.file_bytes);
+                LOG_INFO("[MCL] LoadingOverheadTracker widened UB for group '{}' (handle {}): {}", group, it->second,
+                         existing.ToString());
+            } else {
+                LOG_DEBUG("[MCL] LoadingOverheadTracker re-registered group '{}' (handle {}), UB unchanged", group,
+                          it->second);
             }
-            LOG_INFO("[MCL] LoadingOverheadTracker updated UB for group '{}' (handle {}): {}", group, it->second,
-                     upper_bound.ToString());
             return it->second;
         }
         auto handle = next_handle_++;

--- a/include/cachinglayer/LoadingOverheadTracker.h
+++ b/include/cachinglayer/LoadingOverheadTracker.h
@@ -58,10 +58,12 @@ class LoadingOverheadTracker {
                          it->second, state.ref_count, upper_bound.ToString());
             } else if (state.upper_bound.memory_bytes < upper_bound.memory_bytes ||
                        state.upper_bound.file_bytes < upper_bound.file_bytes) {
+                LOG_WARN(
+                    "[MCL] LoadingOverheadTracker UB mismatch for group '{}' (handle {}): existing={}, new={}. "
+                    "Taking max per dimension.",
+                    group, it->second, state.upper_bound.ToString(), upper_bound.ToString());
                 state.upper_bound.memory_bytes = std::max(state.upper_bound.memory_bytes, upper_bound.memory_bytes);
                 state.upper_bound.file_bytes = std::max(state.upper_bound.file_bytes, upper_bound.file_bytes);
-                LOG_INFO("[MCL] LoadingOverheadTracker widened UB for group '{}' (handle {}, refs={}): {}", group,
-                         it->second, state.ref_count, state.upper_bound.ToString());
             } else {
                 LOG_DEBUG("[MCL] LoadingOverheadTracker re-registered group '{}' (handle {}, refs={}), UB unchanged",
                           group, it->second, state.ref_count);
@@ -70,7 +72,7 @@ class LoadingOverheadTracker {
         }
         auto handle = next_handle_++;
         name_to_handle_[group] = handle;
-        handle_state_[handle] = GroupState{upper_bound, {}, {}, 1};
+        handle_state_[handle] = GroupState{upper_bound, {}, {}, 1, group};
         LOG_INFO("[MCL] LoadingOverheadTracker registered group '{}' (handle {}, refs=1): UB={}", group, handle,
                  upper_bound.ToString());
         return handle;
@@ -166,13 +168,8 @@ class LoadingOverheadTracker {
                 "sum_of_overhead={}, overhead_reserved={}. Cleaning up anyway to avoid leak.",
                 handle, state.sum_of_overhead.ToString(), state.overhead_reserved.ToString());
         }
-        for (auto nit = name_to_handle_.begin(); nit != name_to_handle_.end(); ++nit) {
-            if (nit->second == handle) {
-                LOG_INFO("[MCL] LoadingOverheadTracker unregistered group '{}' (handle {})", nit->first, handle);
-                name_to_handle_.erase(nit);
-                break;
-            }
-        }
+        LOG_INFO("[MCL] LoadingOverheadTracker unregistered group '{}' (handle {})", state.group_name, handle);
+        name_to_handle_.erase(state.group_name);
         handle_state_.erase(it);
     }
 
@@ -182,6 +179,7 @@ class LoadingOverheadTracker {
         ResourceUsage sum_of_overhead;
         ResourceUsage overhead_reserved;
         uint64_t ref_count{0};
+        std::string group_name;
     };
 
     static ResourceUsage

--- a/include/cachinglayer/LoadingOverheadTracker.h
+++ b/include/cachinglayer/LoadingOverheadTracker.h
@@ -74,20 +74,6 @@ class LoadingOverheadTracker {
         return handle;
     }
 
-    // Ensure a group is registered. If not yet registered, registers with kUnlimited.
-    uint64_t
-    EnsureRegistered(const std::string& group) {
-        std::lock_guard<std::mutex> lock(mtx_);
-        auto it = name_to_handle_.find(group);
-        if (it != name_to_handle_.end()) {
-            return it->second;
-        }
-        auto handle = next_handle_++;
-        name_to_handle_[group] = handle;
-        handle_state_[handle] = GroupState{kUnlimited, {}, {}};
-        return handle;
-    }
-
     // Called before loading. Returns the delta to reserve from DList for loading overhead.
     ResourceUsage
     Reserve(uint64_t handle, const ResourceUsage& loading_overhead) {

--- a/include/cachinglayer/Manager.h
+++ b/include/cachinglayer/Manager.h
@@ -64,14 +64,9 @@ class Manager {
         auto evictable = translator->meta()->support_eviction && eviction_enabled_;
         auto self_reserve = eviction_enabled_;
 
-        uint64_t overhead_handle = 0;
-        if (auto& lo = translator->meta()->loading_overhead) {
-            overhead_handle = loading_overhead_tracker_->Register(lo->group, lo->upper_bound);
-        }
-
-        auto cache_slot = std::make_shared<CacheSlot<CellT>>(
-            std::move(translator), dlist_.get(), evictable, self_reserve, config.storage_usage_tracking_enabled,
-            config.loading_timeout, config.warmup_loading_timeout, overhead_handle);
+        auto cache_slot = std::make_shared<CacheSlot<CellT>>(std::move(translator), dlist_.get(), evictable,
+                                                             self_reserve, config.storage_usage_tracking_enabled,
+                                                             config.loading_timeout, config.warmup_loading_timeout);
         cache_slot->Warmup(ctx, prefetch_pool_);
         return cache_slot;
     }

--- a/include/cachinglayer/Manager.h
+++ b/include/cachinglayer/Manager.h
@@ -64,19 +64,22 @@ class Manager {
         auto evictable = translator->meta()->support_eviction && eviction_enabled_;
         auto self_reserve = eviction_enabled_;
 
-        // Register loading overhead upper bound for this CellDataType.
-        // If the translator specifies a finite UB, use it; otherwise register
-        // with unlimited UB to ensure every type goes through the tracker.
+        // Register loading overhead group. The group key defaults to
+        // the CellDataType name, but translators can override via Meta.
+        auto group_key = translator->meta()->loading_overhead_group.empty()
+                             ? std::to_string(static_cast<int>(translator->meta()->cell_data_type))
+                             : translator->meta()->loading_overhead_group;
+        uint64_t overhead_handle = 0;
         if (translator->meta()->loading_overhead_upper_bound.has_value()) {
-            loading_overhead_tracker_.RegisterUpperBound(translator->meta()->cell_data_type,
-                                                         translator->meta()->loading_overhead_upper_bound.value());
+            overhead_handle = loading_overhead_tracker_->Register(
+                group_key, translator->meta()->loading_overhead_upper_bound.value());
         } else {
-            loading_overhead_tracker_.EnsureRegistered(translator->meta()->cell_data_type);
+            overhead_handle = loading_overhead_tracker_->EnsureRegistered(group_key);
         }
 
         auto cache_slot = std::make_shared<CacheSlot<CellT>>(
             std::move(translator), dlist_.get(), evictable, self_reserve, config.storage_usage_tracking_enabled,
-            config.loading_timeout, config.warmup_loading_timeout, &loading_overhead_tracker_);
+            config.loading_timeout, config.warmup_loading_timeout, overhead_handle);
         cache_slot->Warmup(ctx, prefetch_pool_);
         return cache_slot;
     }
@@ -156,7 +159,8 @@ class Manager {
 
     std::shared_ptr<internal::DList> dlist_{nullptr};
     std::shared_ptr<folly::CPUThreadPoolExecutor> prefetch_pool_{nullptr};
-    LoadingOverheadTracker loading_overhead_tracker_;
+    std::shared_ptr<LoadingOverheadTracker> loading_overhead_tracker_ =
+        std::make_shared<LoadingOverheadTracker>();
     bool eviction_enabled_{false};
 };  // class Manager
 

--- a/include/cachinglayer/Manager.h
+++ b/include/cachinglayer/Manager.h
@@ -151,8 +151,7 @@ class Manager {
 
     std::shared_ptr<internal::DList> dlist_{nullptr};
     std::shared_ptr<folly::CPUThreadPoolExecutor> prefetch_pool_{nullptr};
-    std::shared_ptr<LoadingOverheadTracker> loading_overhead_tracker_ =
-        std::make_shared<LoadingOverheadTracker>();
+    std::shared_ptr<LoadingOverheadTracker> loading_overhead_tracker_ = std::make_shared<LoadingOverheadTracker>();
     bool eviction_enabled_{false};
 };  // class Manager
 

--- a/include/cachinglayer/Manager.h
+++ b/include/cachinglayer/Manager.h
@@ -64,17 +64,9 @@ class Manager {
         auto evictable = translator->meta()->support_eviction && eviction_enabled_;
         auto self_reserve = eviction_enabled_;
 
-        // Register loading overhead group. The group key defaults to
-        // the CellDataType name, but translators can override via Meta.
-        auto group_key = translator->meta()->loading_overhead_group.empty()
-                             ? std::to_string(static_cast<int>(translator->meta()->cell_data_type))
-                             : translator->meta()->loading_overhead_group;
         uint64_t overhead_handle = 0;
-        if (translator->meta()->loading_overhead_upper_bound.has_value()) {
-            overhead_handle = loading_overhead_tracker_->Register(
-                group_key, translator->meta()->loading_overhead_upper_bound.value());
-        } else {
-            overhead_handle = loading_overhead_tracker_->EnsureRegistered(group_key);
+        if (auto& lo = translator->meta()->loading_overhead) {
+            overhead_handle = loading_overhead_tracker_->Register(lo->group, lo->upper_bound);
         }
 
         auto cache_slot = std::make_shared<CacheSlot<CellT>>(

--- a/include/cachinglayer/Translator.h
+++ b/include/cachinglayer/Translator.h
@@ -22,6 +22,11 @@
 
 namespace milvus::cachinglayer {
 
+struct LoadingOverheadConfig {
+    ResourceUsage upper_bound;
+    std::string group;
+};
+
 struct Meta {
     // This storage type is currently used only by metrics to distinguish the slot type.
     // In actual resource reservation, we use the actual size of the cell to determine the type.
@@ -32,26 +37,21 @@ struct Meta {
     // Whether the translator supports strategy based eviction.
     // Does not affect manual eviction.
     bool support_eviction;
-    // Upper bound for loading overhead reservation for this CellDataType.
-    // When set, the total loading overhead across all CacheSlots of this type
-    // is capped at this value, preventing over-reservation when many concurrent
+    // Loading overhead configuration for this translator.
+    // When set, the total loading overhead across all CacheSlots sharing the same group
+    // is capped at upper_bound, preventing over-reservation when many concurrent
     // loads happen. The real resource usage is bounded by loading_pool_size * cell_size.
     // If not set, no capping is applied (existing behavior).
-    std::optional<ResourceUsage> loading_overhead_upper_bound;
-    // Group key for overhead capping. Translators sharing the same key share one UB.
-    // If empty, defaults to a string representation of cell_data_type.
-    std::string loading_overhead_group;
+    std::optional<LoadingOverheadConfig> loading_overhead;
     explicit Meta(StorageType storage_type, CellIdMappingMode cell_id_mapping_mode, CellDataType cell_data_type,
                   CacheWarmupPolicy cache_warmup_policy, bool support_eviction,
-                  std::optional<ResourceUsage> loading_overhead_upper_bound = std::nullopt,
-                  std::string loading_overhead_group = "")
+                  std::optional<LoadingOverheadConfig> loading_overhead = std::nullopt)
         : storage_type(storage_type),
           cell_id_mapping_mode(cell_id_mapping_mode),
           cell_data_type(cell_data_type),
           cache_warmup_policy(cache_warmup_policy),
           support_eviction(support_eviction),
-          loading_overhead_upper_bound(loading_overhead_upper_bound),
-          loading_overhead_group(std::move(loading_overhead_group)) {
+          loading_overhead(std::move(loading_overhead)) {
     }
 };
 

--- a/include/cachinglayer/Translator.h
+++ b/include/cachinglayer/Translator.h
@@ -38,15 +38,20 @@ struct Meta {
     // loads happen. The real resource usage is bounded by loading_pool_size * cell_size.
     // If not set, no capping is applied (existing behavior).
     std::optional<ResourceUsage> loading_overhead_upper_bound;
+    // Group key for overhead capping. Translators sharing the same key share one UB.
+    // If empty, defaults to a string representation of cell_data_type.
+    std::string loading_overhead_group;
     explicit Meta(StorageType storage_type, CellIdMappingMode cell_id_mapping_mode, CellDataType cell_data_type,
                   CacheWarmupPolicy cache_warmup_policy, bool support_eviction,
-                  std::optional<ResourceUsage> loading_overhead_upper_bound = std::nullopt)
+                  std::optional<ResourceUsage> loading_overhead_upper_bound = std::nullopt,
+                  std::string loading_overhead_group = "")
         : storage_type(storage_type),
           cell_id_mapping_mode(cell_id_mapping_mode),
           cell_data_type(cell_data_type),
           cache_warmup_policy(cache_warmup_policy),
           support_eviction(support_eviction),
-          loading_overhead_upper_bound(loading_overhead_upper_bound) {
+          loading_overhead_upper_bound(loading_overhead_upper_bound),
+          loading_overhead_group(std::move(loading_overhead_group)) {
     }
 };
 

--- a/include/cachinglayer/lrucache/DList.h
+++ b/include/cachinglayer/lrucache/DList.h
@@ -139,13 +139,12 @@ class DList : public std::enable_shared_from_this<DList> {
     // Returns the actual reserved size (zero = failure).
     folly::SemiFuture<ResourceUsage>
     ReserveLoadingResourceWithTimeout(const ResourceUsage& loaded, const ResourceUsage& overhead,
-                                      uint64_t overhead_handle,
-                                      std::chrono::milliseconds timeout, OpContext* ctx = nullptr);
+                                      uint64_t overhead_handle, std::chrono::milliseconds timeout,
+                                      OpContext* ctx = nullptr);
 
     // Release with loading overhead tracker integration.
     void
-    ReleaseLoadingResource(const ResourceUsage& loaded, const ResourceUsage& overhead,
-                           uint64_t overhead_handle);
+    ReleaseLoadingResource(const ResourceUsage& loaded, const ResourceUsage& overhead, uint64_t overhead_handle);
 
     // Release resource used for loading, called after loading a cell.
     void

--- a/include/cachinglayer/lrucache/DList.h
+++ b/include/cachinglayer/lrucache/DList.h
@@ -160,7 +160,8 @@ class DList : public std::enable_shared_from_this<DList> {
                                       OpContext* ctx = nullptr);
 
     // Release with loading overhead tracker integration.
-    void
+    // Returns the actual unscaled size released (loaded + tracker_delta).
+    ResourceUsage
     ReleaseLoadingResource(const ResourceUsage& loaded, const ResourceUsage& overhead, uint64_t overhead_handle);
 
     // Release resource used for loading, called after loading a cell.
@@ -272,6 +273,11 @@ class DList : public std::enable_shared_from_this<DList> {
     // reserveResource without taking lock, must be called with lock held.
     bool
     reserveResourceInternal(const ResourceUsage& size);
+
+    // Common implementation for resource reservation with eviction.
+    // Returns {success, scaled_size_reserved}.
+    std::pair<bool, ResourceUsage>
+    reserveResourceInternalImpl(const ResourceUsage& size, std::function<void()> rollback);
 
     // Reserve with tracker under lock. Space check uses loaded + overhead,
     // actual reservation uses loaded + tracker delta. Returns actual reserved (zero = failed).

--- a/include/cachinglayer/lrucache/DList.h
+++ b/include/cachinglayer/lrucache/DList.h
@@ -24,6 +24,7 @@
 #include <queue>
 #include <unordered_map>
 
+#include "cachinglayer/LoadingOverheadTracker.h"
 #include "cachinglayer/Metrics.h"
 #include "cachinglayer/Utils.h"
 #include "cachinglayer/lrucache/ListNode.h"
@@ -65,6 +66,11 @@ class DList : public std::enable_shared_from_this<DList> {
             LOG_INFO("[MCL] Starting periodic background eviction loop thread");
             bg_eviction_thread_ = std::thread(&DList::evictionLoop, this);
         }
+    }
+
+    void
+    SetLoadingOverheadTracker(std::shared_ptr<LoadingOverheadTracker> tracker) {
+        loading_overhead_tracker_ = std::move(tracker);
     }
 
     ~DList() {
@@ -127,6 +133,20 @@ class DList : public std::enable_shared_from_this<DList> {
     ReserveLoadingResourceWithTimeout(const ResourceUsage& size, std::chrono::milliseconds timeout,
                                       OpContext* ctx = nullptr);
 
+    // Reserve with loading overhead tracker integration.
+    // Space check uses (loaded + overhead) * factor as upper bound.
+    // Actual reservation uses (loaded + delta) * factor, where delta = tracker->Reserve() or overhead if no tracker.
+    // Returns the actual reserved size (zero = failure).
+    folly::SemiFuture<ResourceUsage>
+    ReserveLoadingResourceWithTimeout(const ResourceUsage& loaded, const ResourceUsage& overhead,
+                                      uint64_t overhead_handle,
+                                      std::chrono::milliseconds timeout, OpContext* ctx = nullptr);
+
+    // Release with loading overhead tracker integration.
+    void
+    ReleaseLoadingResource(const ResourceUsage& loaded, const ResourceUsage& overhead,
+                           uint64_t overhead_handle);
+
     // Release resource used for loading, called after loading a cell.
     void
     ReleaseLoadingResource(const ResourceUsage& loading_size);
@@ -170,15 +190,47 @@ class DList : public std::enable_shared_from_this<DList> {
 
     // Waiting request for timeout-based memory reservation
     struct WaitingRequest {
-        ResourceUsage required_size;
+        ResourceUsage required_size;  // loaded + overhead (for space check)
+        ResourceUsage loaded;         // loaded portion (for tracker-aware path)
+        ResourceUsage overhead;       // overhead portion (for tracker-aware path)
+        uint64_t overhead_handle{0};
         std::chrono::steady_clock::time_point deadline;
-        folly::Promise<bool> promise;
+        folly::Promise<bool> bool_promise;
+        folly::Promise<ResourceUsage> resource_promise;
+        bool use_resource_promise{false};
         uint64_t request_id;
         std::optional<folly::CancellationCallback> cancel_cb{std::nullopt};
 
+        // Legacy constructor (no tracker)
         WaitingRequest(ResourceUsage size, std::chrono::steady_clock::time_point dl, folly::Promise<bool> p,
                        uint64_t id)
-            : required_size(size), deadline(dl), promise(std::move(p)), request_id(id) {
+            : required_size(size), deadline(dl), bool_promise(std::move(p)), request_id(id) {
+        }
+
+        // Tracker-aware constructor.
+        // Note: required_size uses loaded + overhead (uncapped upper bound) for queue ordering.
+        // The actual reservation may be smaller after tracker capping, which means the queue
+        // ordering is conservative — a later request that fits may wait behind one that doesn't.
+        // This matches the existing legacy behavior where the queue breaks on the first unsatisfied head.
+        WaitingRequest(ResourceUsage loaded, ResourceUsage overhead, uint64_t overhead_handle,
+                       std::chrono::steady_clock::time_point dl, folly::Promise<ResourceUsage> p, uint64_t id)
+            : required_size(loaded + overhead),
+              loaded(loaded),
+              overhead(overhead),
+              overhead_handle(overhead_handle),
+              deadline(dl),
+              resource_promise(std::move(p)),
+              use_resource_promise(true),
+              request_id(id) {
+        }
+
+        void
+        setValue(bool success, ResourceUsage actual = {}) {
+            if (use_resource_promise) {
+                resource_promise.setValue(success ? actual : ResourceUsage{});
+            } else {
+                bool_promise.setValue(success);
+            }
         }
     };
 
@@ -200,6 +252,13 @@ class DList : public std::enable_shared_from_this<DList> {
     // reserveResource without taking lock, must be called with lock held.
     bool
     reserveResourceInternal(const ResourceUsage& size);
+
+    // Reserve with tracker under lock. Space check uses loaded + overhead,
+    // actual reservation uses loaded + tracker delta. Returns actual reserved (zero = failed).
+    // Returns {success, unscaled_reserved}. Scaled amount is added to total_loading_size_ internally.
+    std::pair<bool, ResourceUsage>
+    reserveResourceInternalWithTracker(const ResourceUsage& loaded, const ResourceUsage& overhead,
+                                       uint64_t overhead_handle, LoadingOverheadTracker* tracker);
 
     void
     evictionLoop();
@@ -262,6 +321,8 @@ class DList : public std::enable_shared_from_this<DList> {
     // tail_ <- prev <- ... <- head_
     ListNode* head_ = nullptr;
     ListNode* tail_ = nullptr;
+
+    std::shared_ptr<LoadingOverheadTracker> loading_overhead_tracker_;
 
     // TODO(tiered storage 3): benchmark folly::DistributedMutex for this usecase.
     mutable std::mutex list_mtx_;

--- a/include/cachinglayer/lrucache/DList.h
+++ b/include/cachinglayer/lrucache/DList.h
@@ -203,7 +203,11 @@ class DList : public std::enable_shared_from_this<DList> {
         // Legacy constructor (no tracker)
         WaitingRequest(ResourceUsage size, std::chrono::steady_clock::time_point dl, folly::Promise<bool> p,
                        uint64_t id)
-            : required_size(size), deadline(dl), bool_promise(std::move(p)), request_id(id) {
+            : required_size(size),
+              deadline(dl),
+              bool_promise(std::move(p)),
+              resource_promise(folly::Promise<ResourceUsage>::makeEmpty()),
+              request_id(id) {
         }
 
         // Tracker-aware constructor.
@@ -218,6 +222,7 @@ class DList : public std::enable_shared_from_this<DList> {
               overhead(overhead),
               overhead_handle(overhead_handle),
               deadline(dl),
+              bool_promise(folly::Promise<bool>::makeEmpty()),
               resource_promise(std::move(p)),
               use_resource_promise(true),
               request_id(id) {

--- a/include/cachinglayer/lrucache/DList.h
+++ b/include/cachinglayer/lrucache/DList.h
@@ -68,9 +68,26 @@ class DList : public std::enable_shared_from_this<DList> {
         }
     }
 
+    // Must be called during initialization, before any Reserve/Release calls.
+    // Not thread-safe with concurrent Reserve/Release.
     void
     SetLoadingOverheadTracker(std::shared_ptr<LoadingOverheadTracker> tracker) {
         loading_overhead_tracker_ = std::move(tracker);
+    }
+
+    uint64_t
+    RegisterLoadingOverhead(const std::string& group, const ResourceUsage& upper_bound) {
+        if (loading_overhead_tracker_) {
+            return loading_overhead_tracker_->Register(group, upper_bound);
+        }
+        return LoadingOverheadTracker::kInvalidHandle;
+    }
+
+    void
+    UnregisterLoadingOverhead(uint64_t overhead_handle) {
+        if (loading_overhead_tracker_) {
+            loading_overhead_tracker_->Unregister(overhead_handle);
+        }
     }
 
     ~DList() {
@@ -211,13 +228,12 @@ class DList : public std::enable_shared_from_this<DList> {
         }
 
         // Tracker-aware constructor.
-        // Note: required_size uses loaded + overhead (uncapped upper bound) for queue ordering.
-        // The actual reservation may be smaller after tracker capping, which means the queue
-        // ordering is conservative — a later request that fits may wait behind one that doesn't.
-        // This matches the existing legacy behavior where the queue breaks on the first unsatisfied head.
+        // required_size is scaled by loading_resource_factor to match the legacy path,
+        // ensuring consistent queue ordering between legacy and tracker-aware requests.
         WaitingRequest(ResourceUsage loaded, ResourceUsage overhead, uint64_t overhead_handle,
-                       std::chrono::steady_clock::time_point dl, folly::Promise<ResourceUsage> p, uint64_t id)
-            : required_size(loaded + overhead),
+                       std::chrono::steady_clock::time_point dl, folly::Promise<ResourceUsage> p, uint64_t id,
+                       float loading_resource_factor)
+            : required_size((loaded + overhead) * loading_resource_factor),
               loaded(loaded),
               overhead(overhead),
               overhead_handle(overhead_handle),

--- a/src/cachinglayer/Manager.cpp
+++ b/src/cachinglayer/Manager.cpp
@@ -58,6 +58,7 @@ Manager::ConfigureTieredStorage(CacheWarmupPolicies warmup_policies, CacheLimit 
 
         manager.dlist_ =
             std::make_shared<internal::DList>(eviction_enabled, max, low_watermark, high_watermark, eviction_config);
+        manager.dlist_->SetLoadingOverheadTracker(manager.loading_overhead_tracker_);
 
         LOG_INFO(
             "[MCL] Configured Tiered Storage manager with "

--- a/src/cachinglayer/lrucache/DList.cpp
+++ b/src/cachinglayer/lrucache/DList.cpp
@@ -62,7 +62,8 @@ DList::ReserveLoadingResourceWithTimeout(const ResourceUsage& loaded, const Reso
     uint64_t request_id = next_request_id_.fetch_add(1);
 
     auto waiting_request =
-        std::make_unique<WaitingRequest>(loaded, overhead, overhead_handle, deadline, std::move(promise), request_id);
+        std::make_unique<WaitingRequest>(loaded, overhead, overhead_handle, deadline, std::move(promise), request_id,
+                                         eviction_config_.loading_resource_factor);
     WaitingRequest* request_ptr = waiting_request.get();
     waiting_requests_map_[request_id] = request_ptr;
     waiting_queue_.push(std::move(waiting_request));
@@ -301,7 +302,7 @@ DList::reserveResourceInternalWithTracker(const ResourceUsage& loaded, const Res
     // Compute tracker delta first so space check uses the actual amount, not the uncapped overhead.
     // This avoids rejecting loads that would fit after tracker capping (e.g., delta=0 when group is saturated).
     auto delta = overhead;
-    if (overhead_handle != LoadingOverheadTracker::kInvalidHandle) {
+    if (overhead_handle != LoadingOverheadTracker::kInvalidHandle && tracker != nullptr) {
         delta = tracker->Reserve(overhead_handle, overhead);
     }
     auto actual_size = (loaded + delta) * eviction_config_.loading_resource_factor;
@@ -343,7 +344,7 @@ DList::reserveResourceInternalWithTracker(const ResourceUsage& loaded, const Res
                 loaded.ToString(), overhead.ToString(), delta.ToString(), eviction_target.ToString(),
                 min_eviction.ToString());
             // Rollback tracker state on failure
-            if (overhead_handle != LoadingOverheadTracker::kInvalidHandle) {
+            if (overhead_handle != LoadingOverheadTracker::kInvalidHandle && tracker != nullptr) {
                 tracker->Release(overhead_handle, overhead);
             }
             return {false, {}};
@@ -648,7 +649,7 @@ DList::ReleaseLoadingResource(const ResourceUsage& loaded, const ResourceUsage& 
     {
         std::unique_lock<std::mutex> lock(list_mtx_);
         auto delta = overhead;
-        if (overhead_handle != LoadingOverheadTracker::kInvalidHandle) {
+        if (overhead_handle != LoadingOverheadTracker::kInvalidHandle && loading_overhead_tracker_) {
             delta = loading_overhead_tracker_->Release(overhead_handle, overhead);
         }
         auto actual = (loaded + delta) * eviction_config_.loading_resource_factor;
@@ -875,18 +876,32 @@ DList::handleWaitingRequests() {
                 auto rollback =
                     request->use_resource_promise ? actual * eviction_config_.loading_resource_factor : actual;
                 total_loading_size_ -= rollback;
-                if (request->overhead_handle != LoadingOverheadTracker::kInvalidHandle) {
+                if (request->overhead_handle != LoadingOverheadTracker::kInvalidHandle && loading_overhead_tracker_) {
                     loading_overhead_tracker_->Release(request->overhead_handle, request->overhead);
                 }
             }
             requests_to_destroy.push_back(std::move(request));
             waiting_queue_.pop();
         } else {
+            // Check if this request is permanently impossible (required size exceeds capacity).
+            // If so, fail it immediately instead of blocking the entire queue until timeout.
+            if (!max_resource_limit_.load().CanHold(request_ptr_ref->required_size)) {
+                auto request = std::move(request_ptr_ref);
+                if (waiting_requests_map_.erase(request->request_id) > 0) {
+                    LOG_WARN(
+                        "[MCL] Request {} is permanently impossible (required_size={} > capacity={}), "
+                        "failing immediately.",
+                        request->request_id, request->required_size.ToString(), max_resource_limit_.load().ToString());
+                    request->setValue(false);
+                }
+                requests_to_destroy.push_back(std::move(request));
+                waiting_queue_.pop();
+                continue;
+            }
             LOG_DEBUG("[MCL] Request {} of size {} cannot be satisfied, breaking.", request_ptr_ref->request_id,
                       request_ptr_ref->required_size.ToString());
-            // Cannot satisfy even with eviction.
-            // The largest/oldest obstacle is at the top of the queue.
-            // No point trying for smaller requests.
+            // Cannot satisfy right now but may succeed later.
+            // The queue is ordered by deadline, so stop here.
             break;
         }
     }

--- a/src/cachinglayer/lrucache/DList.cpp
+++ b/src/cachinglayer/lrucache/DList.cpp
@@ -35,6 +35,84 @@ ClampNonNegative(std::atomic<ResourceUsage>& counter, LogFn&& log_fn) {
     }
 }
 
+folly::SemiFuture<ResourceUsage>
+DList::ReserveLoadingResourceWithTimeout(const ResourceUsage& loaded, const ResourceUsage& overhead,
+                                         uint64_t overhead_handle,
+                                         std::chrono::milliseconds timeout, OpContext* ctx) {
+    // Quick reject: if even loaded alone (minimum possible) exceeds capacity, fail fast.
+    auto min_possible = loaded * eviction_config_.loading_resource_factor;
+    std::unique_lock<std::mutex> lock(list_mtx_);
+    if (!max_resource_limit_.load().CanHold(min_possible)) {
+        LOG_ERROR("[MCL] Failed to reserve loaded={} as it exceeds max_memory_={}.",
+                  loaded.ToString(), max_resource_limit_.load().ToString());
+        return folly::makeSemiFuture(ResourceUsage{});
+    }
+    auto [success, actual] =
+        reserveResourceInternalWithTracker(loaded, overhead, overhead_handle, loading_overhead_tracker_.get());
+    if (success) {
+        return folly::makeSemiFuture(actual);
+    }
+
+    if (timeout.count() == 0) {
+        return folly::makeSemiFuture(ResourceUsage{});
+    }
+
+    auto deadline =
+        timeout.count() > 0 ? std::chrono::steady_clock::now() + timeout : std::chrono::steady_clock::time_point::max();
+    auto [promise, future] = folly::makePromiseContract<ResourceUsage>();
+    uint64_t request_id = next_request_id_.fetch_add(1);
+
+    auto waiting_request = std::make_unique<WaitingRequest>(
+        loaded, overhead, overhead_handle, deadline, std::move(promise), request_id);
+    WaitingRequest* request_ptr = waiting_request.get();
+    waiting_requests_map_[request_id] = request_ptr;
+    waiting_queue_.push(std::move(waiting_request));
+    waiting_queue_empty_ = false;
+    std::weak_ptr<DList> weak_self = shared_from_this();
+
+    if (timeout.count() > 0) {
+        LOG_DEBUG("[MCL] Request {} loaded={} overhead={} added to waiting queue, timeout={}ms",
+                  request_id, loaded.ToString(), overhead.ToString(), timeout.count());
+
+        event_base_thread_->getEventBase()->runInEventBaseThread([weak_self, request_id, timeout]() {
+            auto self = weak_self.lock();
+            if (!self) return;
+            self->event_base_thread_->getEventBase()->runAfterDelay(
+                [weak_self, request_id]() {
+                    auto self = weak_self.lock();
+                    if (!self) return;
+                    std::unique_lock<std::mutex> lock(self->list_mtx_);
+                    auto it = self->waiting_requests_map_.find(request_id);
+                    if (it != self->waiting_requests_map_.end()) {
+                        LOG_WARN("[MCL] Reserve Request {} timed out.", request_id);
+                        it->second->setValue(false);
+                        self->waiting_requests_map_.erase(it);
+                    }
+                },
+                static_cast<uint32_t>(timeout.count()));
+        });
+    }
+
+    if (ctx && ctx->cancellation_token.canBeCancelled()) {
+        request_ptr->cancel_cb.emplace(ctx->cancellation_token, [weak_self, request_id]() {
+            auto self = weak_self.lock();
+            if (!self) return;
+            self->event_base_thread_->getEventBase()->runInEventBaseThread([weak_self, request_id]() {
+                auto self = weak_self.lock();
+                if (!self) return;
+                std::unique_lock<std::mutex> lock(self->list_mtx_);
+                auto it = self->waiting_requests_map_.find(request_id);
+                if (it == self->waiting_requests_map_.end()) return;
+                LOG_WARN("[MCL] Request {} cancelled.", request_id);
+                it->second->setValue(false);
+                self->waiting_requests_map_.erase(it);
+            });
+        });
+    }
+
+    return std::move(future);
+}
+
 folly::SemiFuture<bool>
 DList::ReserveLoadingResourceWithTimeout(const ResourceUsage& original_size, std::chrono::milliseconds timeout,
                                          OpContext* ctx) {
@@ -97,7 +175,7 @@ DList::ReserveLoadingResourceWithTimeout(const ResourceUsage& original_size, std
                             "[MCL] Reserve Request {} of size {} timed out, "
                             "notifying failure.",
                             request_id, it->second->required_size.ToString());
-                        it->second->promise.setValue(false);
+                        it->second->setValue(false);
                         self->waiting_requests_map_.erase(it);
                     }
                 },
@@ -125,7 +203,7 @@ DList::ReserveLoadingResourceWithTimeout(const ResourceUsage& original_size, std
                     return;
                 }
                 LOG_WARN("[MCL] Request {} cancelled, notifying failure.", request_id);
-                it->second->promise.setValue(false);
+                it->second->setValue(false);
                 self->waiting_requests_map_.erase(it);
             });
         });
@@ -211,6 +289,68 @@ DList::reserveResourceInternal(const ResourceUsage& size) {
               size.ToString(), total_loading_size_.load().ToString(), total_loaded_size_.load().ToString());
 
     return true;
+}
+
+std::pair<bool, ResourceUsage>
+DList::reserveResourceInternalWithTracker(const ResourceUsage& loaded, const ResourceUsage& overhead,
+                                          uint64_t overhead_handle, LoadingOverheadTracker* tracker) {
+    // Compute tracker delta first so space check uses the actual amount, not the uncapped overhead.
+    // This avoids rejecting loads that would fit after tracker capping (e.g., delta=0 when group is saturated).
+    auto delta = overhead;
+    if (overhead_handle != LoadingOverheadTracker::kInvalidHandle) {
+        delta = tracker->Reserve(overhead_handle, overhead);
+    }
+    auto actual_size = (loaded + delta) * eviction_config_.loading_resource_factor;
+    auto using_resources = total_loaded_size_.load() + total_loading_size_.load();
+
+    bool logical_limit_exceeded = !max_resource_limit_.load().CanHold(using_resources + actual_size);
+    auto physical_eviction_needed = checkPhysicalMemoryLimit(actual_size);
+
+    while (logical_limit_exceeded || physical_eviction_needed.AnyGTZero()) {
+        ResourceUsage eviction_target;
+        ResourceUsage min_eviction;
+
+        if (logical_limit_exceeded) {
+            eviction_target = using_resources + actual_size - low_watermark_;
+            min_eviction = using_resources + actual_size - max_resource_limit_.load();
+            if (eviction_target.memory_bytes < 0) eviction_target.memory_bytes = 0;
+            if (eviction_target.file_bytes < 0) eviction_target.file_bytes = 0;
+            if (min_eviction.memory_bytes < 0) min_eviction.memory_bytes = 0;
+            if (min_eviction.file_bytes < 0) min_eviction.file_bytes = 0;
+        }
+
+        if (physical_eviction_needed.AnyGTZero()) {
+            eviction_target.memory_bytes = std::max(eviction_target.memory_bytes, physical_eviction_needed.memory_bytes);
+            eviction_target.file_bytes = std::max(eviction_target.file_bytes, physical_eviction_needed.file_bytes);
+            min_eviction.memory_bytes = std::max(min_eviction.memory_bytes, physical_eviction_needed.memory_bytes);
+            min_eviction.file_bytes = std::max(min_eviction.file_bytes, physical_eviction_needed.file_bytes);
+        }
+
+        ResourceUsage evicted_size = tryEvict(eviction_target, min_eviction);
+        if (!evicted_size.AnyGTZero()) {
+            LOG_WARN("[MCL] reserve with tracker failed: loaded={}, overhead={}, delta={}, eviction_target={}, "
+                     "min_eviction={}",
+                     loaded.ToString(), overhead.ToString(), delta.ToString(),
+                     eviction_target.ToString(), min_eviction.ToString());
+            // Rollback tracker state on failure
+            if (overhead_handle != LoadingOverheadTracker::kInvalidHandle) {
+                tracker->Release(overhead_handle, overhead);
+            }
+            return {false, {}};
+        }
+        logical_limit_exceeded = false;
+
+        if (!physical_eviction_needed.AnyGTZero()) break;
+        if (physical_eviction_needed = checkPhysicalMemoryLimit(actual_size); !physical_eviction_needed.AnyGTZero())
+            break;
+    }
+
+    total_loading_size_ += actual_size;
+    auto unscaled = loaded + delta;
+    LOG_TRACE("[MCL] reserve with tracker: loaded={}, overhead={}, delta={}, unscaled={}, scaled={}, total_loading={}",
+              loaded.ToString(), overhead.ToString(), delta.ToString(), unscaled.ToString(),
+              actual_size.ToString(), total_loading_size_.load().ToString());
+    return {true, unscaled};
 }
 
 void
@@ -492,6 +632,28 @@ DList::UpdateHighWatermark(const ResourceUsage& new_high_watermark) {
 }
 
 void
+DList::ReleaseLoadingResource(const ResourceUsage& loaded, const ResourceUsage& overhead,
+                               uint64_t overhead_handle) {
+    std::vector<std::unique_ptr<WaitingRequest>> to_destroy;
+    {
+        std::unique_lock<std::mutex> lock(list_mtx_);
+        auto delta = overhead;
+        if (overhead_handle != LoadingOverheadTracker::kInvalidHandle) {
+            delta = loading_overhead_tracker_->Release(overhead_handle, overhead);
+        }
+        auto actual = (loaded + delta) * eviction_config_.loading_resource_factor;
+        total_loading_size_ -= actual;
+        ClampNonNegative(total_loading_size_, [&](const ResourceUsage& curr) {
+            LOG_ERROR("[MCL] total_loading_size_ negative after tracker release: loaded={}, overhead={}, delta={}, "
+                      "current={}",
+                      loaded.ToString(), overhead.ToString(), delta.ToString(), curr.ToString());
+        });
+        to_destroy = handleWaitingRequests();
+    }
+    // Destroy requests outside lock to avoid deadlock with cancel callbacks
+}
+
+void
 DList::ReleaseLoadingResource(const ResourceUsage& loading_size) {
     auto size = loading_size * eviction_config_.loading_resource_factor;
     total_loading_size_ -= size;
@@ -663,7 +825,7 @@ DList::handleWaitingRequests() {
                     "[MCL] Request {} expired, cleaned up by "
                     "handleWaitingRequests.",
                     request->request_id);
-                request->promise.setValue(false);
+                request->setValue(false);
             }
             // If erase returned 0, the timeout/cancel handler ran first and claimed the
             // request. We don't need to do anything with the promise.
@@ -673,20 +835,41 @@ DList::handleWaitingRequests() {
             continue;
         }
 
-        if (reserveResourceInternal(request_ptr_ref->required_size)) {
+        // Try to fulfill: tracker-aware path computes delta under lock,
+        // legacy path uses required_size directly.
+        bool fulfilled = false;
+        ResourceUsage actual{};
+        if (request_ptr_ref->use_resource_promise) {
+            auto [ok, unscaled] = reserveResourceInternalWithTracker(
+                request_ptr_ref->loaded, request_ptr_ref->overhead,
+                request_ptr_ref->overhead_handle, loading_overhead_tracker_.get());
+            fulfilled = ok;
+            actual = unscaled;
+        } else {
+            if (reserveResourceInternal(request_ptr_ref->required_size)) {
+                fulfilled = true;
+                actual = request_ptr_ref->required_size;
+            }
+        }
+        if (fulfilled) {
             auto request = std::move(request_ptr_ref);
 
             if (waiting_requests_map_.erase(request->request_id) > 0) {
-                // Success - notify the request
                 LOG_DEBUG("[MCL] Executing success notification for request {}", request->request_id);
-                request->promise.setValue(true);
+                request->setValue(true, actual);
             } else {
-                // Request was already handled by timeout/cancel, rollback reserved resource.
+                // Request was already handled by timeout/cancel, rollback.
+                // Legacy: actual is already scaled. Tracker-aware: actual is unscaled, needs scaling.
                 LOG_WARN(
-                    "[MCL] Request {} of size {} was already handled by timeout/cancel, rolling back reserved "
-                    "resource.",
-                    request->request_id, request->required_size.ToString());
-                total_loading_size_ -= request->required_size;
+                    "[MCL] Request {} was already handled by timeout/cancel, rolling back.",
+                    request->request_id);
+                auto rollback = request->use_resource_promise
+                                    ? actual * eviction_config_.loading_resource_factor
+                                    : actual;
+                total_loading_size_ -= rollback;
+                if (request->overhead_handle != LoadingOverheadTracker::kInvalidHandle) {
+                    loading_overhead_tracker_->Release(request->overhead_handle, request->overhead);
+                }
             }
             requests_to_destroy.push_back(std::move(request));
             waiting_queue_.pop();
@@ -719,7 +902,7 @@ DList::clearWaitingQueue() {
 
             // Only setValue if this request hasn't been handled by timeout/cancel
             if (waiting_requests_map_.erase(request->request_id) > 0) {
-                request->promise.setValue(false);
+                request->setValue(false);
             }
             requests_to_destroy.push_back(std::move(request));
         }

--- a/src/cachinglayer/lrucache/DList.cpp
+++ b/src/cachinglayer/lrucache/DList.cpp
@@ -219,6 +219,42 @@ DList::ReserveLoadingResourceWithTimeout(const ResourceUsage& original_size, std
 
 bool
 DList::reserveResourceInternal(const ResourceUsage& size) {
+    auto rollback = []() {};
+    auto [success, _] = reserveResourceInternalImpl(size, rollback);
+    return success;
+}
+
+std::pair<bool, ResourceUsage>
+DList::reserveResourceInternalWithTracker(const ResourceUsage& loaded, const ResourceUsage& overhead,
+                                          uint64_t overhead_handle, LoadingOverheadTracker* tracker) {
+    // Compute tracker delta first so space check uses the actual amount, not the uncapped overhead.
+    // This avoids rejecting loads that would fit after tracker capping (e.g., delta=0 when group is saturated).
+    auto delta = overhead;
+    if (overhead_handle != LoadingOverheadTracker::kInvalidHandle && tracker != nullptr) {
+        delta = tracker->Reserve(overhead_handle, overhead);
+    }
+    auto actual_size = (loaded + delta) * eviction_config_.loading_resource_factor;
+
+    auto rollback = [overhead_handle, overhead, tracker]() {
+        if (overhead_handle != LoadingOverheadTracker::kInvalidHandle && tracker != nullptr) {
+            tracker->Release(overhead_handle, overhead);
+        }
+    };
+
+    auto [success, _] = reserveResourceInternalImpl(actual_size, rollback);
+    if (!success) {
+        return {false, {}};
+    }
+
+    auto unscaled = loaded + delta;
+    LOG_TRACE("[MCL] reserve with tracker: loaded={}, overhead={}, delta={}, unscaled={}, scaled={}, total_loading={}",
+              loaded.ToString(), overhead.ToString(), delta.ToString(), unscaled.ToString(), actual_size.ToString(),
+              total_loading_size_.load().ToString());
+    return {true, unscaled};
+}
+
+std::pair<bool, ResourceUsage>
+DList::reserveResourceInternalImpl(const ResourceUsage& size, std::function<void()> rollback) {
     auto using_resources = total_loaded_size_.load() + total_loading_size_.load();
 
     // Combined logical and physical memory limit check
@@ -268,10 +304,13 @@ DList::reserveResourceInternal(const ResourceUsage& size) {
                 "[MCL] reserve resource with size={} failed due to all zero evicted_size, "
                 "eviction_target={}, min_eviction={}",
                 size.ToString(), eviction_target.ToString(), min_eviction.ToString());
-            return false;
+            rollback();
+            return {false, {}};
         }
+
+        using_resources -= evicted_size;
         // logical limit is accurate, thus we can guarantee after one successful eviction, logical limit is satisfied.
-        logical_limit_exceeded = false;
+        logical_limit_exceeded = !max_resource_limit_.load().CanHold(using_resources + size);
 
         if (!physical_eviction_needed.AnyGTZero()) {
             // we only need to evict for logical limit and we have succeeded.
@@ -290,79 +329,10 @@ DList::reserveResourceInternal(const ResourceUsage& size) {
     }
 
     total_loading_size_ += size;
-    LOG_TRACE("[MCL] reserve resource with size={} success, total_loading_size={}, total_loaded_size={}",
-              size.ToString(), total_loading_size_.load().ToString(), total_loaded_size_.load().ToString());
+    LOG_TRACE("[MCL] reserve resource success, size={}, total_loading_size={}, total_loaded_size={}", size.ToString(),
+              total_loading_size_.load().ToString(), total_loaded_size_.load().ToString());
 
-    return true;
-}
-
-std::pair<bool, ResourceUsage>
-DList::reserveResourceInternalWithTracker(const ResourceUsage& loaded, const ResourceUsage& overhead,
-                                          uint64_t overhead_handle, LoadingOverheadTracker* tracker) {
-    // Compute tracker delta first so space check uses the actual amount, not the uncapped overhead.
-    // This avoids rejecting loads that would fit after tracker capping (e.g., delta=0 when group is saturated).
-    auto delta = overhead;
-    if (overhead_handle != LoadingOverheadTracker::kInvalidHandle && tracker != nullptr) {
-        delta = tracker->Reserve(overhead_handle, overhead);
-    }
-    auto actual_size = (loaded + delta) * eviction_config_.loading_resource_factor;
-    auto using_resources = total_loaded_size_.load() + total_loading_size_.load();
-
-    bool logical_limit_exceeded = !max_resource_limit_.load().CanHold(using_resources + actual_size);
-    auto physical_eviction_needed = checkPhysicalMemoryLimit(actual_size);
-
-    while (logical_limit_exceeded || physical_eviction_needed.AnyGTZero()) {
-        ResourceUsage eviction_target;
-        ResourceUsage min_eviction;
-
-        if (logical_limit_exceeded) {
-            eviction_target = using_resources + actual_size - low_watermark_;
-            min_eviction = using_resources + actual_size - max_resource_limit_.load();
-            if (eviction_target.memory_bytes < 0)
-                eviction_target.memory_bytes = 0;
-            if (eviction_target.file_bytes < 0)
-                eviction_target.file_bytes = 0;
-            if (min_eviction.memory_bytes < 0)
-                min_eviction.memory_bytes = 0;
-            if (min_eviction.file_bytes < 0)
-                min_eviction.file_bytes = 0;
-        }
-
-        if (physical_eviction_needed.AnyGTZero()) {
-            eviction_target.memory_bytes =
-                std::max(eviction_target.memory_bytes, physical_eviction_needed.memory_bytes);
-            eviction_target.file_bytes = std::max(eviction_target.file_bytes, physical_eviction_needed.file_bytes);
-            min_eviction.memory_bytes = std::max(min_eviction.memory_bytes, physical_eviction_needed.memory_bytes);
-            min_eviction.file_bytes = std::max(min_eviction.file_bytes, physical_eviction_needed.file_bytes);
-        }
-
-        ResourceUsage evicted_size = tryEvict(eviction_target, min_eviction);
-        if (!evicted_size.AnyGTZero()) {
-            LOG_WARN(
-                "[MCL] reserve with tracker failed: loaded={}, overhead={}, delta={}, eviction_target={}, "
-                "min_eviction={}",
-                loaded.ToString(), overhead.ToString(), delta.ToString(), eviction_target.ToString(),
-                min_eviction.ToString());
-            // Rollback tracker state on failure
-            if (overhead_handle != LoadingOverheadTracker::kInvalidHandle && tracker != nullptr) {
-                tracker->Release(overhead_handle, overhead);
-            }
-            return {false, {}};
-        }
-        logical_limit_exceeded = false;
-
-        if (!physical_eviction_needed.AnyGTZero())
-            break;
-        if (physical_eviction_needed = checkPhysicalMemoryLimit(actual_size); !physical_eviction_needed.AnyGTZero())
-            break;
-    }
-
-    total_loading_size_ += actual_size;
-    auto unscaled = loaded + delta;
-    LOG_TRACE("[MCL] reserve with tracker: loaded={}, overhead={}, delta={}, unscaled={}, scaled={}, total_loading={}",
-              loaded.ToString(), overhead.ToString(), delta.ToString(), unscaled.ToString(), actual_size.ToString(),
-              total_loading_size_.load().ToString());
-    return {true, unscaled};
+    return {true, size};
 }
 
 void
@@ -643,16 +613,18 @@ DList::UpdateHighWatermark(const ResourceUsage& new_high_watermark) {
     cachinglayer::monitor::cache_high_watermark_bytes(StorageType::DISK).Set(high_watermark_.load().file_bytes);
 }
 
-void
+ResourceUsage
 DList::ReleaseLoadingResource(const ResourceUsage& loaded, const ResourceUsage& overhead, uint64_t overhead_handle) {
     std::vector<std::unique_ptr<WaitingRequest>> to_destroy;
+    ResourceUsage unscaled{};
     {
         std::unique_lock<std::mutex> lock(list_mtx_);
         auto delta = overhead;
         if (overhead_handle != LoadingOverheadTracker::kInvalidHandle && loading_overhead_tracker_) {
             delta = loading_overhead_tracker_->Release(overhead_handle, overhead);
         }
-        auto actual = (loaded + delta) * eviction_config_.loading_resource_factor;
+        unscaled = loaded + delta;
+        auto actual = unscaled * eviction_config_.loading_resource_factor;
         total_loading_size_ -= actual;
         ClampNonNegative(total_loading_size_, [&](const ResourceUsage& curr) {
             LOG_ERROR(
@@ -663,6 +635,7 @@ DList::ReleaseLoadingResource(const ResourceUsage& loaded, const ResourceUsage& 
         to_destroy = handleWaitingRequests();
     }
     // Destroy requests outside lock to avoid deadlock with cancel callbacks
+    return unscaled;
 }
 
 void
@@ -884,7 +857,8 @@ DList::handleWaitingRequests() {
             waiting_queue_.pop();
         } else {
             // Check if this request is permanently impossible (required size exceeds capacity).
-            // If so, fail it immediately instead of blocking the entire queue until timeout.
+            // Use required_size for both paths: (loaded + overhead) * factor for tracker-aware,
+            // which is the upper bound of what the request could need.
             if (!max_resource_limit_.load().CanHold(request_ptr_ref->required_size)) {
                 auto request = std::move(request_ptr_ref);
                 if (waiting_requests_map_.erase(request->request_id) > 0) {

--- a/src/cachinglayer/lrucache/DList.cpp
+++ b/src/cachinglayer/lrucache/DList.cpp
@@ -37,14 +37,13 @@ ClampNonNegative(std::atomic<ResourceUsage>& counter, LogFn&& log_fn) {
 
 folly::SemiFuture<ResourceUsage>
 DList::ReserveLoadingResourceWithTimeout(const ResourceUsage& loaded, const ResourceUsage& overhead,
-                                         uint64_t overhead_handle,
-                                         std::chrono::milliseconds timeout, OpContext* ctx) {
+                                         uint64_t overhead_handle, std::chrono::milliseconds timeout, OpContext* ctx) {
     // Quick reject: if even loaded alone (minimum possible) exceeds capacity, fail fast.
     auto min_possible = loaded * eviction_config_.loading_resource_factor;
     std::unique_lock<std::mutex> lock(list_mtx_);
     if (!max_resource_limit_.load().CanHold(min_possible)) {
-        LOG_ERROR("[MCL] Failed to reserve loaded={} as it exceeds max_memory_={}.",
-                  loaded.ToString(), max_resource_limit_.load().ToString());
+        LOG_ERROR("[MCL] Failed to reserve loaded={} as it exceeds max_memory_={}.", loaded.ToString(),
+                  max_resource_limit_.load().ToString());
         return folly::makeSemiFuture(ResourceUsage{});
     }
     auto [success, actual] =
@@ -62,8 +61,8 @@ DList::ReserveLoadingResourceWithTimeout(const ResourceUsage& loaded, const Reso
     auto [promise, future] = folly::makePromiseContract<ResourceUsage>();
     uint64_t request_id = next_request_id_.fetch_add(1);
 
-    auto waiting_request = std::make_unique<WaitingRequest>(
-        loaded, overhead, overhead_handle, deadline, std::move(promise), request_id);
+    auto waiting_request =
+        std::make_unique<WaitingRequest>(loaded, overhead, overhead_handle, deadline, std::move(promise), request_id);
     WaitingRequest* request_ptr = waiting_request.get();
     waiting_requests_map_[request_id] = request_ptr;
     waiting_queue_.push(std::move(waiting_request));
@@ -71,16 +70,18 @@ DList::ReserveLoadingResourceWithTimeout(const ResourceUsage& loaded, const Reso
     std::weak_ptr<DList> weak_self = shared_from_this();
 
     if (timeout.count() > 0) {
-        LOG_DEBUG("[MCL] Request {} loaded={} overhead={} added to waiting queue, timeout={}ms",
-                  request_id, loaded.ToString(), overhead.ToString(), timeout.count());
+        LOG_DEBUG("[MCL] Request {} loaded={} overhead={} added to waiting queue, timeout={}ms", request_id,
+                  loaded.ToString(), overhead.ToString(), timeout.count());
 
         event_base_thread_->getEventBase()->runInEventBaseThread([weak_self, request_id, timeout]() {
             auto self = weak_self.lock();
-            if (!self) return;
+            if (!self)
+                return;
             self->event_base_thread_->getEventBase()->runAfterDelay(
                 [weak_self, request_id]() {
                     auto self = weak_self.lock();
-                    if (!self) return;
+                    if (!self)
+                        return;
                     std::unique_lock<std::mutex> lock(self->list_mtx_);
                     auto it = self->waiting_requests_map_.find(request_id);
                     if (it != self->waiting_requests_map_.end()) {
@@ -96,13 +97,16 @@ DList::ReserveLoadingResourceWithTimeout(const ResourceUsage& loaded, const Reso
     if (ctx && ctx->cancellation_token.canBeCancelled()) {
         request_ptr->cancel_cb.emplace(ctx->cancellation_token, [weak_self, request_id]() {
             auto self = weak_self.lock();
-            if (!self) return;
+            if (!self)
+                return;
             self->event_base_thread_->getEventBase()->runInEventBaseThread([weak_self, request_id]() {
                 auto self = weak_self.lock();
-                if (!self) return;
+                if (!self)
+                    return;
                 std::unique_lock<std::mutex> lock(self->list_mtx_);
                 auto it = self->waiting_requests_map_.find(request_id);
-                if (it == self->waiting_requests_map_.end()) return;
+                if (it == self->waiting_requests_map_.end())
+                    return;
                 LOG_WARN("[MCL] Request {} cancelled.", request_id);
                 it->second->setValue(false);
                 self->waiting_requests_map_.erase(it);
@@ -313,14 +317,19 @@ DList::reserveResourceInternalWithTracker(const ResourceUsage& loaded, const Res
         if (logical_limit_exceeded) {
             eviction_target = using_resources + actual_size - low_watermark_;
             min_eviction = using_resources + actual_size - max_resource_limit_.load();
-            if (eviction_target.memory_bytes < 0) eviction_target.memory_bytes = 0;
-            if (eviction_target.file_bytes < 0) eviction_target.file_bytes = 0;
-            if (min_eviction.memory_bytes < 0) min_eviction.memory_bytes = 0;
-            if (min_eviction.file_bytes < 0) min_eviction.file_bytes = 0;
+            if (eviction_target.memory_bytes < 0)
+                eviction_target.memory_bytes = 0;
+            if (eviction_target.file_bytes < 0)
+                eviction_target.file_bytes = 0;
+            if (min_eviction.memory_bytes < 0)
+                min_eviction.memory_bytes = 0;
+            if (min_eviction.file_bytes < 0)
+                min_eviction.file_bytes = 0;
         }
 
         if (physical_eviction_needed.AnyGTZero()) {
-            eviction_target.memory_bytes = std::max(eviction_target.memory_bytes, physical_eviction_needed.memory_bytes);
+            eviction_target.memory_bytes =
+                std::max(eviction_target.memory_bytes, physical_eviction_needed.memory_bytes);
             eviction_target.file_bytes = std::max(eviction_target.file_bytes, physical_eviction_needed.file_bytes);
             min_eviction.memory_bytes = std::max(min_eviction.memory_bytes, physical_eviction_needed.memory_bytes);
             min_eviction.file_bytes = std::max(min_eviction.file_bytes, physical_eviction_needed.file_bytes);
@@ -328,10 +337,11 @@ DList::reserveResourceInternalWithTracker(const ResourceUsage& loaded, const Res
 
         ResourceUsage evicted_size = tryEvict(eviction_target, min_eviction);
         if (!evicted_size.AnyGTZero()) {
-            LOG_WARN("[MCL] reserve with tracker failed: loaded={}, overhead={}, delta={}, eviction_target={}, "
-                     "min_eviction={}",
-                     loaded.ToString(), overhead.ToString(), delta.ToString(),
-                     eviction_target.ToString(), min_eviction.ToString());
+            LOG_WARN(
+                "[MCL] reserve with tracker failed: loaded={}, overhead={}, delta={}, eviction_target={}, "
+                "min_eviction={}",
+                loaded.ToString(), overhead.ToString(), delta.ToString(), eviction_target.ToString(),
+                min_eviction.ToString());
             // Rollback tracker state on failure
             if (overhead_handle != LoadingOverheadTracker::kInvalidHandle) {
                 tracker->Release(overhead_handle, overhead);
@@ -340,7 +350,8 @@ DList::reserveResourceInternalWithTracker(const ResourceUsage& loaded, const Res
         }
         logical_limit_exceeded = false;
 
-        if (!physical_eviction_needed.AnyGTZero()) break;
+        if (!physical_eviction_needed.AnyGTZero())
+            break;
         if (physical_eviction_needed = checkPhysicalMemoryLimit(actual_size); !physical_eviction_needed.AnyGTZero())
             break;
     }
@@ -348,8 +359,8 @@ DList::reserveResourceInternalWithTracker(const ResourceUsage& loaded, const Res
     total_loading_size_ += actual_size;
     auto unscaled = loaded + delta;
     LOG_TRACE("[MCL] reserve with tracker: loaded={}, overhead={}, delta={}, unscaled={}, scaled={}, total_loading={}",
-              loaded.ToString(), overhead.ToString(), delta.ToString(), unscaled.ToString(),
-              actual_size.ToString(), total_loading_size_.load().ToString());
+              loaded.ToString(), overhead.ToString(), delta.ToString(), unscaled.ToString(), actual_size.ToString(),
+              total_loading_size_.load().ToString());
     return {true, unscaled};
 }
 
@@ -632,8 +643,7 @@ DList::UpdateHighWatermark(const ResourceUsage& new_high_watermark) {
 }
 
 void
-DList::ReleaseLoadingResource(const ResourceUsage& loaded, const ResourceUsage& overhead,
-                               uint64_t overhead_handle) {
+DList::ReleaseLoadingResource(const ResourceUsage& loaded, const ResourceUsage& overhead, uint64_t overhead_handle) {
     std::vector<std::unique_ptr<WaitingRequest>> to_destroy;
     {
         std::unique_lock<std::mutex> lock(list_mtx_);
@@ -644,9 +654,10 @@ DList::ReleaseLoadingResource(const ResourceUsage& loaded, const ResourceUsage& 
         auto actual = (loaded + delta) * eviction_config_.loading_resource_factor;
         total_loading_size_ -= actual;
         ClampNonNegative(total_loading_size_, [&](const ResourceUsage& curr) {
-            LOG_ERROR("[MCL] total_loading_size_ negative after tracker release: loaded={}, overhead={}, delta={}, "
-                      "current={}",
-                      loaded.ToString(), overhead.ToString(), delta.ToString(), curr.ToString());
+            LOG_ERROR(
+                "[MCL] total_loading_size_ negative after tracker release: loaded={}, overhead={}, delta={}, "
+                "current={}",
+                loaded.ToString(), overhead.ToString(), delta.ToString(), curr.ToString());
         });
         to_destroy = handleWaitingRequests();
     }
@@ -840,9 +851,9 @@ DList::handleWaitingRequests() {
         bool fulfilled = false;
         ResourceUsage actual{};
         if (request_ptr_ref->use_resource_promise) {
-            auto [ok, unscaled] = reserveResourceInternalWithTracker(
-                request_ptr_ref->loaded, request_ptr_ref->overhead,
-                request_ptr_ref->overhead_handle, loading_overhead_tracker_.get());
+            auto [ok, unscaled] =
+                reserveResourceInternalWithTracker(request_ptr_ref->loaded, request_ptr_ref->overhead,
+                                                   request_ptr_ref->overhead_handle, loading_overhead_tracker_.get());
             fulfilled = ok;
             actual = unscaled;
         } else {
@@ -860,12 +871,9 @@ DList::handleWaitingRequests() {
             } else {
                 // Request was already handled by timeout/cancel, rollback.
                 // Legacy: actual is already scaled. Tracker-aware: actual is unscaled, needs scaling.
-                LOG_WARN(
-                    "[MCL] Request {} was already handled by timeout/cancel, rolling back.",
-                    request->request_id);
-                auto rollback = request->use_resource_promise
-                                    ? actual * eviction_config_.loading_resource_factor
-                                    : actual;
+                LOG_WARN("[MCL] Request {} was already handled by timeout/cancel, rolling back.", request->request_id);
+                auto rollback =
+                    request->use_resource_promise ? actual * eviction_config_.loading_resource_factor : actual;
                 total_loading_size_ -= rollback;
                 if (request->overhead_handle != LoadingOverheadTracker::kInvalidHandle) {
                     loading_overhead_tracker_->Release(request->overhead_handle, request->overhead);

--- a/test/test_cachinglayer/test_cache_slot.cpp
+++ b/test/test_cachinglayer/test_cache_slot.cpp
@@ -1874,8 +1874,7 @@ TEST(CacheSlotTrackerTest, LoadingOverheadTrackerIntegration) {
 
     auto cache_slot =
         std::make_shared<CacheSlot<TestCell>>(std::move(translator), dlist.get(), true, true, false,
-                                              std::chrono::milliseconds(5000), std::chrono::milliseconds(0),
-                                              handle);
+                                              std::chrono::milliseconds(5000), std::chrono::milliseconds(0), handle);
 
     auto op_ctx = std::make_unique<milvus::OpContext>();
 
@@ -1913,8 +1912,7 @@ TEST(CacheSlotTrackerTest, LoadingOverheadTrackerCleanupOnException) {
 
     auto cache_slot =
         std::make_shared<CacheSlot<TestCell>>(std::move(translator), dlist.get(), true, true, false,
-                                              std::chrono::milliseconds(5000), std::chrono::milliseconds(0),
-                                              handle);
+                                              std::chrono::milliseconds(5000), std::chrono::milliseconds(0), handle);
 
     auto op_ctx = std::make_unique<milvus::OpContext>();
 
@@ -1955,8 +1953,7 @@ TEST(CacheSlotTrackerTest, BonusCellsRetryWithTracker) {
 
     auto cache_slot =
         std::make_shared<CacheSlot<TestCell>>(std::move(translator), dlist.get(), true, true, false,
-                                              std::chrono::milliseconds(200), std::chrono::milliseconds(0),
-                                              handle);
+                                              std::chrono::milliseconds(200), std::chrono::milliseconds(0), handle);
 
     auto op_ctx = std::make_unique<milvus::OpContext>();
 

--- a/test/test_cachinglayer/test_cache_slot.cpp
+++ b/test/test_cachinglayer/test_cache_slot.cpp
@@ -1858,8 +1858,8 @@ TEST(CacheSlotTrackerTest, LoadingOverheadTrackerIntegration) {
     ResourceUsage limit{10000, 0};
     auto dlist = std::make_shared<DList>(true, limit, limit, limit, EvictionConfig{10, true, 600});
 
-    LoadingOverheadTracker tracker;
-    tracker.RegisterUpperBound(CellDataType::OTHER, {500, 0});
+    auto tracker = std::make_shared<LoadingOverheadTracker>();
+    auto handle = tracker->Register("test_group", {500, 0});
 
     const int64_t cell_loaded_size = 100;
     const int64_t cell_loading_overhead = 200;
@@ -1870,9 +1870,12 @@ TEST(CacheSlotTrackerTest, LoadingOverheadTrackerIntegration) {
     translator->SetLoadingOverheadBytes(cell_loading_overhead);
     auto* translator_ptr = translator.get();
 
+    dlist->SetLoadingOverheadTracker(tracker);
+
     auto cache_slot =
         std::make_shared<CacheSlot<TestCell>>(std::move(translator), dlist.get(), true, true, false,
-                                              std::chrono::milliseconds(5000), std::chrono::milliseconds(0), &tracker);
+                                              std::chrono::milliseconds(5000), std::chrono::milliseconds(0),
+                                              handle);
 
     auto op_ctx = std::make_unique<milvus::OpContext>();
 
@@ -1894,8 +1897,8 @@ TEST(CacheSlotTrackerTest, LoadingOverheadTrackerCleanupOnException) {
     ResourceUsage limit{10000, 0};
     auto dlist = std::make_shared<DList>(true, limit, limit, limit, EvictionConfig{10, true, 600});
 
-    LoadingOverheadTracker tracker;
-    tracker.RegisterUpperBound(CellDataType::OTHER, {500, 0});
+    auto tracker = std::make_shared<LoadingOverheadTracker>();
+    auto handle = tracker->Register("test_group", {500, 0});
 
     const int64_t cell_loaded_size = 100;
     const int64_t cell_loading_overhead = 200;
@@ -1906,22 +1909,22 @@ TEST(CacheSlotTrackerTest, LoadingOverheadTrackerCleanupOnException) {
     translator->SetLoadingOverheadBytes(cell_loading_overhead);
     translator->SetShouldThrow(true);
 
+    dlist->SetLoadingOverheadTracker(tracker);
+
     auto cache_slot =
         std::make_shared<CacheSlot<TestCell>>(std::move(translator), dlist.get(), true, true, false,
-                                              std::chrono::milliseconds(5000), std::chrono::milliseconds(0), &tracker);
+                                              std::chrono::milliseconds(5000), std::chrono::milliseconds(0),
+                                              handle);
 
     auto op_ctx = std::make_unique<milvus::OpContext>();
 
     // Pin should fail because translator throws, but tracker state must be cleaned up.
-    // The exception is caught internally by RunLoad and set as error on the cell.
     EXPECT_ANY_THROW(cache_slot->PinCellsDirect(op_ctx.get(), {0}));
 
-    // After the failed load, tracker state should be clean.
-    // Verify by reserving again — if state leaked, the tracker would have stale sum_of_overhead.
-    // Reserve the full UB amount — should succeed fully if no leak.
-    auto delta = tracker.Reserve(CellDataType::OTHER, {500, 0});
+    // Verify tracker state is clean by reserving the full UB.
+    auto delta = tracker->Reserve(handle, {500, 0});
     EXPECT_EQ(delta.memory_bytes, 500);
 
-    auto release = tracker.Release(CellDataType::OTHER, {500, 0});
+    auto release = tracker->Release(handle, {500, 0});
     EXPECT_EQ(release.memory_bytes, 500);
 }

--- a/test/test_cachinglayer/test_cache_slot.cpp
+++ b/test/test_cachinglayer/test_cache_slot.cpp
@@ -183,6 +183,10 @@ class MockTranslator : public Translator<TestCell> {
     SetLoadingOverheadBytes(int64_t bytes) {
         loading_overhead_bytes_ = bytes;
     }
+    void
+    SetLoadingOverheadConfig(const std::string& group, const ResourceUsage& upper_bound) {
+        meta_.loading_overhead = LoadingOverheadConfig{upper_bound, group};
+    }
     int
     GetCellsCallCount() const {
         EXPECT_FALSE(for_concurrent_test_);
@@ -1859,7 +1863,7 @@ TEST(CacheSlotTrackerTest, LoadingOverheadTrackerIntegration) {
     auto dlist = std::make_shared<DList>(true, limit, limit, limit, EvictionConfig{10, true, 600});
 
     auto tracker = std::make_shared<LoadingOverheadTracker>();
-    auto handle = tracker->Register("test_group", {500, 0});
+    dlist->SetLoadingOverheadTracker(tracker);
 
     const int64_t cell_loaded_size = 100;
     const int64_t cell_loading_overhead = 200;
@@ -1868,13 +1872,12 @@ TEST(CacheSlotTrackerTest, LoadingOverheadTrackerIntegration) {
         std::vector<std::pair<cid_t, int64_t>>{{0, cell_loaded_size}, {1, cell_loaded_size}},
         std::unordered_map<cl_uid_t, cid_t>{{0, 0}, {1, 1}}, "test_tracker_integration", StorageType::MEMORY);
     translator->SetLoadingOverheadBytes(cell_loading_overhead);
+    translator->SetLoadingOverheadConfig("test_group", {500, 0});
     auto* translator_ptr = translator.get();
-
-    dlist->SetLoadingOverheadTracker(tracker);
 
     auto cache_slot =
         std::make_shared<CacheSlot<TestCell>>(std::move(translator), dlist.get(), true, true, false,
-                                              std::chrono::milliseconds(5000), std::chrono::milliseconds(0), handle);
+                                              std::chrono::milliseconds(5000), std::chrono::milliseconds(0));
 
     auto op_ctx = std::make_unique<milvus::OpContext>();
 
@@ -1897,7 +1900,7 @@ TEST(CacheSlotTrackerTest, LoadingOverheadTrackerCleanupOnException) {
     auto dlist = std::make_shared<DList>(true, limit, limit, limit, EvictionConfig{10, true, 600});
 
     auto tracker = std::make_shared<LoadingOverheadTracker>();
-    auto handle = tracker->Register("test_group", {500, 0});
+    dlist->SetLoadingOverheadTracker(tracker);
 
     const int64_t cell_loaded_size = 100;
     const int64_t cell_loading_overhead = 200;
@@ -1906,18 +1909,20 @@ TEST(CacheSlotTrackerTest, LoadingOverheadTrackerCleanupOnException) {
                                                        std::unordered_map<cl_uid_t, cid_t>{{0, 0}},
                                                        "test_tracker_exception", StorageType::MEMORY);
     translator->SetLoadingOverheadBytes(cell_loading_overhead);
+    translator->SetLoadingOverheadConfig("test_group", {500, 0});
     translator->SetShouldThrow(true);
-
-    dlist->SetLoadingOverheadTracker(tracker);
 
     auto cache_slot =
         std::make_shared<CacheSlot<TestCell>>(std::move(translator), dlist.get(), true, true, false,
-                                              std::chrono::milliseconds(5000), std::chrono::milliseconds(0), handle);
+                                              std::chrono::milliseconds(5000), std::chrono::milliseconds(0));
 
     auto op_ctx = std::make_unique<milvus::OpContext>();
 
     // Pin should fail because translator throws, but tracker state must be cleaned up.
     EXPECT_ANY_THROW(cache_slot->PinCellsDirect(op_ctx.get(), {0}));
+
+    // Register again to get handle for verification (CacheSlot registered internally).
+    auto handle = tracker->Register("test_group", {500, 0});
 
     // Verify tracker state is clean by reserving the full UB.
     auto delta = tracker->Reserve(handle, {500, 0});
@@ -1935,7 +1940,6 @@ TEST(CacheSlotTrackerTest, BonusCellsRetryWithTracker) {
     auto dlist = std::make_shared<DList>(true, limit, limit, limit, EvictionConfig{10, true, 600});
 
     auto tracker = std::make_shared<LoadingOverheadTracker>();
-    auto handle = tracker->Register("test_bonus_retry", {100, 0});
     dlist->SetLoadingOverheadTracker(tracker);
 
     const int64_t cell_loaded_size = 100;
@@ -1949,11 +1953,12 @@ TEST(CacheSlotTrackerTest, BonusCellsRetryWithTracker) {
         std::vector<std::pair<cid_t, int64_t>>{{0, cell_loaded_size}, {1, cell_loaded_size}, {2, cell_loaded_size}},
         std::unordered_map<cl_uid_t, cid_t>{{0, 0}, {1, 1}, {2, 2}}, "test_bonus_retry", StorageType::MEMORY);
     translator->SetLoadingOverheadBytes(cell_loading_overhead);
+    translator->SetLoadingOverheadConfig("test_bonus_retry", {100, 0});
     translator->SetExtraReturnCids({{0, {1, 2}}});
 
     auto cache_slot =
         std::make_shared<CacheSlot<TestCell>>(std::move(translator), dlist.get(), true, true, false,
-                                              std::chrono::milliseconds(200), std::chrono::milliseconds(0), handle);
+                                              std::chrono::milliseconds(200), std::chrono::milliseconds(0));
 
     auto op_ctx = std::make_unique<milvus::OpContext>();
 

--- a/test/test_cachinglayer/test_cache_slot.cpp
+++ b/test/test_cachinglayer/test_cache_slot.cpp
@@ -1928,3 +1928,46 @@ TEST(CacheSlotTrackerTest, LoadingOverheadTrackerCleanupOnException) {
     auto release = tracker->Release(handle, {500, 0});
     EXPECT_EQ(release.memory_bytes, 500);
 }
+
+// Test bonus cells retry path with tracker: essential+bonus exceeds DList capacity,
+// falls back to essential-only which succeeds.
+TEST(CacheSlotTrackerTest, BonusCellsRetryWithTracker) {
+    // Tight capacity: can hold 2 cells (200 bytes) + overhead (up to UB=100), but not 3 cells (300).
+    ResourceUsage limit{350, 0};
+    auto dlist = std::make_shared<DList>(true, limit, limit, limit, EvictionConfig{10, true, 600});
+
+    auto tracker = std::make_shared<LoadingOverheadTracker>();
+    auto handle = tracker->Register("test_bonus_retry", {100, 0});
+    dlist->SetLoadingOverheadTracker(tracker);
+
+    const int64_t cell_loaded_size = 100;
+    const int64_t cell_loading_overhead = 50;
+
+    // 3 cells: cid 0, 1, 2. We'll pin cid 0, with bonus cells {1, 2}.
+    // essential(cid 0) = 100 loaded + 50 overhead = fits in 350
+    // essential+bonus(cid 0,1,2) = 300 loaded + 150 overhead = 450 > 350, should fail
+    // retry essential-only(cid 0) = 100 loaded + delta overhead = fits
+    auto translator = std::make_unique<MockTranslator>(
+        std::vector<std::pair<cid_t, int64_t>>{{0, cell_loaded_size}, {1, cell_loaded_size}, {2, cell_loaded_size}},
+        std::unordered_map<cl_uid_t, cid_t>{{0, 0}, {1, 1}, {2, 2}}, "test_bonus_retry", StorageType::MEMORY);
+    translator->SetLoadingOverheadBytes(cell_loading_overhead);
+    translator->SetExtraReturnCids({{0, {1, 2}}});
+
+    auto cache_slot =
+        std::make_shared<CacheSlot<TestCell>>(std::move(translator), dlist.get(), true, true, false,
+                                              std::chrono::milliseconds(200), std::chrono::milliseconds(0),
+                                              handle);
+
+    auto op_ctx = std::make_unique<milvus::OpContext>();
+
+    // Pin cell 0: bonus retry should kick in, essential-only should succeed.
+    auto accessor = cache_slot->PinCellsDirect(op_ctx.get(), {0});
+    ASSERT_NE(accessor, nullptr);
+    EXPECT_EQ(accessor->get_cell_of(0)->data, 0);
+
+    // Cell 1 and 2 should NOT be loaded (bonus was dropped).
+    // Pin them separately to verify they weren't loaded as bonus.
+    auto accessor2 = cache_slot->PinCellsDirect(op_ctx.get(), {1});
+    ASSERT_NE(accessor2, nullptr);
+    EXPECT_EQ(accessor2->get_cell_of(1)->data, 10);
+}

--- a/test/test_cachinglayer/test_loading_overhead_tracker.cpp
+++ b/test/test_cachinglayer/test_loading_overhead_tracker.cpp
@@ -15,7 +15,7 @@ class LoadingOverheadTrackerTest : public ::testing::Test {
 
 TEST_F(LoadingOverheadTrackerTest, NoUpperBoundPassThrough) {
     // Without registering a UB, all amounts pass through unchanged.
-    auto handle = tracker_.EnsureRegistered("vector_index");
+    auto handle = tracker_.Register("vector_index", LoadingOverheadTracker::kUnlimited);
     auto delta = tracker_.Reserve(handle, {100, 0});
     EXPECT_EQ(delta.memory_bytes, 100);
     EXPECT_EQ(delta.file_bytes, 0);
@@ -155,12 +155,12 @@ TEST_F(LoadingOverheadTrackerTest, RegisterUpperBoundTakesMax) {
 }
 
 TEST_F(LoadingOverheadTrackerTest, HasFiniteUpperBound) {
-    auto handle = tracker_.EnsureRegistered("vector_index");
+    auto handle = tracker_.Register("vector_index", LoadingOverheadTracker::kUnlimited);
     EXPECT_FALSE(tracker_.HasFiniteUpperBound(handle));
     handle = tracker_.Register("vector_index", {200, 0});
     EXPECT_TRUE(tracker_.HasFiniteUpperBound(handle));
 
-    auto scalar_handle = tracker_.EnsureRegistered("scalar_field");
+    auto scalar_handle = tracker_.Register("scalar_field", LoadingOverheadTracker::kUnlimited);
     EXPECT_FALSE(tracker_.HasFiniteUpperBound(scalar_handle));
 }
 
@@ -196,8 +196,8 @@ TEST_F(LoadingOverheadTrackerTest, ConcurrentReserveRelease) {
 }
 
 TEST_F(LoadingOverheadTrackerTest, DefaultUnlimitedUBFallback) {
-    // EnsureRegistered without explicit UB -> unlimited, behaves like no capping.
-    auto handle = tracker_.EnsureRegistered("vector_index");
+    // Register with kUnlimited -> unlimited, behaves like no capping.
+    auto handle = tracker_.Register("vector_index", LoadingOverheadTracker::kUnlimited);
 
     EXPECT_FALSE(tracker_.HasFiniteUpperBound(handle));
 
@@ -214,8 +214,8 @@ TEST_F(LoadingOverheadTrackerTest, DefaultUnlimitedUBFallback) {
     EXPECT_EQ(r2.memory_bytes, 2000000000);
 }
 
-TEST_F(LoadingOverheadTrackerTest, EnsureRegisteredThenRegisterFiniteUB) {
-    auto handle = tracker_.EnsureRegistered("vector_index");
+TEST_F(LoadingOverheadTrackerTest, RegisterUnlimitedThenFiniteUB) {
+    auto handle = tracker_.Register("vector_index", LoadingOverheadTracker::kUnlimited);
     EXPECT_FALSE(tracker_.HasFiniteUpperBound(handle));
 
     handle = tracker_.Register("vector_index", {200, 0});
@@ -227,7 +227,7 @@ TEST_F(LoadingOverheadTrackerTest, EnsureRegisteredThenRegisterFiniteUB) {
 }
 
 TEST_F(LoadingOverheadTrackerTest, UnregisteredTypeAutoCreatesUnlimited) {
-    auto handle = tracker_.EnsureRegistered("scalar_field");
+    auto handle = tracker_.Register("scalar_field", LoadingOverheadTracker::kUnlimited);
     auto d1 = tracker_.Reserve(handle, {500, 0});
     EXPECT_EQ(d1.memory_bytes, 500);
 
@@ -268,7 +268,7 @@ TEST_F(LoadingOverheadTrackerTest, UBChangesMidFlight) {
 }
 
 TEST_F(LoadingOverheadTrackerTest, UBDecreasesFromUnlimitedMidFlight) {
-    auto handle = tracker_.EnsureRegistered("vector_index");
+    auto handle = tracker_.Register("vector_index", LoadingOverheadTracker::kUnlimited);
     auto d1 = tracker_.Reserve(handle, {1000, 0});
     EXPECT_EQ(d1.memory_bytes, 1000);
     auto d2 = tracker_.Reserve(handle, {1000, 0});
@@ -296,7 +296,7 @@ TEST_F(LoadingOverheadTrackerTest, UBDecreasesFromUnlimitedMidFlight) {
 }
 
 TEST_F(LoadingOverheadTrackerTest, GetUpperBound) {
-    auto handle = tracker_.EnsureRegistered("vector_index");
+    auto handle = tracker_.Register("vector_index", LoadingOverheadTracker::kUnlimited);
     EXPECT_EQ(tracker_.GetUpperBound(handle), LoadingOverheadTracker::kUnlimited);
 
     handle = tracker_.Register("vector_index", {200, 100});

--- a/test/test_cachinglayer/test_loading_overhead_tracker.cpp
+++ b/test/test_cachinglayer/test_loading_overhead_tracker.cpp
@@ -15,153 +15,157 @@ class LoadingOverheadTrackerTest : public ::testing::Test {
 
 TEST_F(LoadingOverheadTrackerTest, NoUpperBoundPassThrough) {
     // Without registering a UB, all amounts pass through unchanged.
-    auto delta = tracker_.Reserve(CellDataType::VECTOR_INDEX, {100, 0});
+    auto handle = tracker_.EnsureRegistered("vector_index");
+    auto delta = tracker_.Reserve(handle, {100, 0});
     EXPECT_EQ(delta.memory_bytes, 100);
     EXPECT_EQ(delta.file_bytes, 0);
 
-    auto release = tracker_.Release(CellDataType::VECTOR_INDEX, {100, 0});
+    auto release = tracker_.Release(handle, {100, 0});
     EXPECT_EQ(release.memory_bytes, 100);
     EXPECT_EQ(release.file_bytes, 0);
 }
 
 TEST_F(LoadingOverheadTrackerTest, BasicCapping) {
-    tracker_.RegisterUpperBound(CellDataType::VECTOR_INDEX, {200, 0});
+    auto handle = tracker_.Register("vector_index", {200, 0});
 
     // First reserve: 100, sum=100 <= UB=200, full amount passes through
-    auto d1 = tracker_.Reserve(CellDataType::VECTOR_INDEX, {100, 0});
+    auto d1 = tracker_.Reserve(handle, {100, 0});
     EXPECT_EQ(d1.memory_bytes, 100);
 
     // Second reserve: 100, sum=200 <= UB=200, full amount passes through
-    auto d2 = tracker_.Reserve(CellDataType::VECTOR_INDEX, {100, 0});
+    auto d2 = tracker_.Reserve(handle, {100, 0});
     EXPECT_EQ(d2.memory_bytes, 100);
 
     // Third reserve: 100, sum=300 > UB=200, capped: delta = 0
-    auto d3 = tracker_.Reserve(CellDataType::VECTOR_INDEX, {100, 0});
+    auto d3 = tracker_.Reserve(handle, {100, 0});
     EXPECT_EQ(d3.memory_bytes, 0);
 
     // Fourth reserve: 100, sum=400 > UB=200, capped: delta = 0
-    auto d4 = tracker_.Reserve(CellDataType::VECTOR_INDEX, {100, 0});
+    auto d4 = tracker_.Reserve(handle, {100, 0});
     EXPECT_EQ(d4.memory_bytes, 0);
 }
 
 TEST_F(LoadingOverheadTrackerTest, BasicRelease) {
-    tracker_.RegisterUpperBound(CellDataType::VECTOR_INDEX, {200, 0});
+    auto handle = tracker_.Register("vector_index", {200, 0});
 
     // Reserve 4x100, total sum=400, actual DList reserve = 200
-    tracker_.Reserve(CellDataType::VECTOR_INDEX, {100, 0});
-    tracker_.Reserve(CellDataType::VECTOR_INDEX, {100, 0});
-    tracker_.Reserve(CellDataType::VECTOR_INDEX, {100, 0});
-    tracker_.Reserve(CellDataType::VECTOR_INDEX, {100, 0});
+    tracker_.Reserve(handle, {100, 0});
+    tracker_.Reserve(handle, {100, 0});
+    tracker_.Reserve(handle, {100, 0});
+    tracker_.Reserve(handle, {100, 0});
 
     // Release first 100: sum 400->300, both >= UB, release 0
-    auto r1 = tracker_.Release(CellDataType::VECTOR_INDEX, {100, 0});
+    auto r1 = tracker_.Release(handle, {100, 0});
     EXPECT_EQ(r1.memory_bytes, 0);
 
     // Release second 100: sum 300->200, release 0
-    auto r2 = tracker_.Release(CellDataType::VECTOR_INDEX, {100, 0});
+    auto r2 = tracker_.Release(handle, {100, 0});
     EXPECT_EQ(r2.memory_bytes, 0);
 
     // Release third 100: sum 200->100, release 100
-    auto r3 = tracker_.Release(CellDataType::VECTOR_INDEX, {100, 0});
+    auto r3 = tracker_.Release(handle, {100, 0});
     EXPECT_EQ(r3.memory_bytes, 100);
 
     // Release fourth 100: sum 100->0, release 100
-    auto r4 = tracker_.Release(CellDataType::VECTOR_INDEX, {100, 0});
+    auto r4 = tracker_.Release(handle, {100, 0});
     EXPECT_EQ(r4.memory_bytes, 100);
 }
 
 TEST_F(LoadingOverheadTrackerTest, TotalReservedEqualsReleased) {
-    tracker_.RegisterUpperBound(CellDataType::VECTOR_INDEX, {200, 0});
+    auto handle = tracker_.Register("vector_index", {200, 0});
 
     int64_t total_reserved = 0;
     int64_t total_released = 0;
 
     // Reserve 10 x 100
     for (int i = 0; i < 10; i++) {
-        total_reserved += tracker_.Reserve(CellDataType::VECTOR_INDEX, {100, 0}).memory_bytes;
+        total_reserved += tracker_.Reserve(handle, {100, 0}).memory_bytes;
     }
     // Should have reserved exactly UB = 200
     EXPECT_EQ(total_reserved, 200);
 
     // Release all 10
     for (int i = 0; i < 10; i++) {
-        total_released += tracker_.Release(CellDataType::VECTOR_INDEX, {100, 0}).memory_bytes;
+        total_released += tracker_.Release(handle, {100, 0}).memory_bytes;
     }
     // Total released should equal total reserved
     EXPECT_EQ(total_released, 200);
 }
 
 TEST_F(LoadingOverheadTrackerTest, PartialCapping) {
-    tracker_.RegisterUpperBound(CellDataType::VECTOR_INDEX, {200, 0});
+    auto handle = tracker_.Register("vector_index", {200, 0});
 
     // Reserve 150: sum=150 <= UB=200, full amount
-    auto d1 = tracker_.Reserve(CellDataType::VECTOR_INDEX, {150, 0});
+    auto d1 = tracker_.Reserve(handle, {150, 0});
     EXPECT_EQ(d1.memory_bytes, 150);
 
     // Reserve 100: sum=250 > UB=200, delta = 200-150 = 50
-    auto d2 = tracker_.Reserve(CellDataType::VECTOR_INDEX, {100, 0});
+    auto d2 = tracker_.Reserve(handle, {100, 0});
     EXPECT_EQ(d2.memory_bytes, 50);
 }
 
 TEST_F(LoadingOverheadTrackerTest, ReleaseUndoesReserve) {
-    tracker_.RegisterUpperBound(CellDataType::VECTOR_INDEX, {200, 0});
+    auto handle = tracker_.Register("vector_index", {200, 0});
 
     // Reserve 150: actual = 150
-    auto d1 = tracker_.Reserve(CellDataType::VECTOR_INDEX, {150, 0});
+    auto d1 = tracker_.Reserve(handle, {150, 0});
     EXPECT_EQ(d1.memory_bytes, 150);
 
     // Release undoes the reserve: sum 150->0, release = 150
-    auto undo = tracker_.Release(CellDataType::VECTOR_INDEX, {150, 0});
+    auto undo = tracker_.Release(handle, {150, 0});
     EXPECT_EQ(undo.memory_bytes, 150);
 }
 
 TEST_F(LoadingOverheadTrackerTest, MultipleTypes) {
-    tracker_.RegisterUpperBound(CellDataType::VECTOR_INDEX, {200, 0});
-    tracker_.RegisterUpperBound(CellDataType::SCALAR_INDEX, {100, 0});
+    auto vec_handle = tracker_.Register("vector_index", {200, 0});
+    auto scalar_handle = tracker_.Register("scalar_field", {100, 0});
 
     // Types are tracked independently
-    auto d1 = tracker_.Reserve(CellDataType::VECTOR_INDEX, {200, 0});
+    auto d1 = tracker_.Reserve(vec_handle, {200, 0});
     EXPECT_EQ(d1.memory_bytes, 200);
 
-    auto d2 = tracker_.Reserve(CellDataType::SCALAR_INDEX, {100, 0});
+    auto d2 = tracker_.Reserve(scalar_handle, {100, 0});
     EXPECT_EQ(d2.memory_bytes, 100);
 
     // Both at UB, further reserves return 0
-    auto d3 = tracker_.Reserve(CellDataType::VECTOR_INDEX, {100, 0});
+    auto d3 = tracker_.Reserve(vec_handle, {100, 0});
     EXPECT_EQ(d3.memory_bytes, 0);
 
-    auto d4 = tracker_.Reserve(CellDataType::SCALAR_INDEX, {50, 0});
+    auto d4 = tracker_.Reserve(scalar_handle, {50, 0});
     EXPECT_EQ(d4.memory_bytes, 0);
 }
 
 TEST_F(LoadingOverheadTrackerTest, RegisterUpperBoundTakesMax) {
-    tracker_.RegisterUpperBound(CellDataType::VECTOR_INDEX, {100, 50});
-    tracker_.RegisterUpperBound(CellDataType::VECTOR_INDEX, {200, 30});
+    auto handle = tracker_.Register("vector_index", {100, 50});
+    handle = tracker_.Register("vector_index", {200, 30});
 
     // UB should be {200, 50} (max per dimension)
-    auto ub = tracker_.GetUpperBound(CellDataType::VECTOR_INDEX);
+    auto ub = tracker_.GetUpperBound(handle);
     EXPECT_EQ(ub.memory_bytes, 200);
     EXPECT_EQ(ub.file_bytes, 50);
 
-    auto d1 = tracker_.Reserve(CellDataType::VECTOR_INDEX, {200, 50});
+    auto d1 = tracker_.Reserve(handle, {200, 50});
     EXPECT_EQ(d1.memory_bytes, 200);
     EXPECT_EQ(d1.file_bytes, 50);
 
     // Next reserve should be fully capped
-    auto d2 = tracker_.Reserve(CellDataType::VECTOR_INDEX, {100, 100});
+    auto d2 = tracker_.Reserve(handle, {100, 100});
     EXPECT_EQ(d2.memory_bytes, 0);
     EXPECT_EQ(d2.file_bytes, 0);
 }
 
 TEST_F(LoadingOverheadTrackerTest, HasFiniteUpperBound) {
-    EXPECT_FALSE(tracker_.HasFiniteUpperBound(CellDataType::VECTOR_INDEX));
-    tracker_.RegisterUpperBound(CellDataType::VECTOR_INDEX, {200, 0});
-    EXPECT_TRUE(tracker_.HasFiniteUpperBound(CellDataType::VECTOR_INDEX));
-    EXPECT_FALSE(tracker_.HasFiniteUpperBound(CellDataType::SCALAR_INDEX));
+    auto handle = tracker_.EnsureRegistered("vector_index");
+    EXPECT_FALSE(tracker_.HasFiniteUpperBound(handle));
+    handle = tracker_.Register("vector_index", {200, 0});
+    EXPECT_TRUE(tracker_.HasFiniteUpperBound(handle));
+
+    auto scalar_handle = tracker_.EnsureRegistered("scalar_field");
+    EXPECT_FALSE(tracker_.HasFiniteUpperBound(scalar_handle));
 }
 
 TEST_F(LoadingOverheadTrackerTest, ConcurrentReserveRelease) {
-    tracker_.RegisterUpperBound(CellDataType::VECTOR_INDEX, {200, 0});
+    auto handle = tracker_.Register("vector_index", {200, 0});
 
     const int num_threads = 10;
     const int ops_per_thread = 100;
@@ -173,11 +177,11 @@ TEST_F(LoadingOverheadTrackerTest, ConcurrentReserveRelease) {
     for (int i = 0; i < num_threads; i++) {
         threads.emplace_back([&]() {
             for (int j = 0; j < ops_per_thread; j++) {
-                auto reserved = tracker_.Reserve(CellDataType::VECTOR_INDEX, {10, 0});
+                auto reserved = tracker_.Reserve(handle, {10, 0});
                 total_reserved += reserved.memory_bytes;
             }
             for (int j = 0; j < ops_per_thread; j++) {
-                auto released = tracker_.Release(CellDataType::VECTOR_INDEX, {10, 0});
+                auto released = tracker_.Release(handle, {10, 0});
                 total_released += released.memory_bytes;
             }
         });
@@ -193,68 +197,69 @@ TEST_F(LoadingOverheadTrackerTest, ConcurrentReserveRelease) {
 
 TEST_F(LoadingOverheadTrackerTest, DefaultUnlimitedUBFallback) {
     // EnsureRegistered without explicit UB -> unlimited, behaves like no capping.
-    tracker_.EnsureRegistered(CellDataType::VECTOR_INDEX);
+    auto handle = tracker_.EnsureRegistered("vector_index");
 
-    EXPECT_FALSE(tracker_.HasFiniteUpperBound(CellDataType::VECTOR_INDEX));
+    EXPECT_FALSE(tracker_.HasFiniteUpperBound(handle));
 
-    auto d1 = tracker_.Reserve(CellDataType::VECTOR_INDEX, {1000000000, 0});
+    auto d1 = tracker_.Reserve(handle, {1000000000, 0});
     EXPECT_EQ(d1.memory_bytes, 1000000000);
 
-    auto d2 = tracker_.Reserve(CellDataType::VECTOR_INDEX, {2000000000, 0});
+    auto d2 = tracker_.Reserve(handle, {2000000000, 0});
     EXPECT_EQ(d2.memory_bytes, 2000000000);
 
-    auto r1 = tracker_.Release(CellDataType::VECTOR_INDEX, {1000000000, 0});
+    auto r1 = tracker_.Release(handle, {1000000000, 0});
     EXPECT_EQ(r1.memory_bytes, 1000000000);
 
-    auto r2 = tracker_.Release(CellDataType::VECTOR_INDEX, {2000000000, 0});
+    auto r2 = tracker_.Release(handle, {2000000000, 0});
     EXPECT_EQ(r2.memory_bytes, 2000000000);
 }
 
 TEST_F(LoadingOverheadTrackerTest, EnsureRegisteredThenRegisterFiniteUB) {
-    tracker_.EnsureRegistered(CellDataType::VECTOR_INDEX);
-    EXPECT_FALSE(tracker_.HasFiniteUpperBound(CellDataType::VECTOR_INDEX));
+    auto handle = tracker_.EnsureRegistered("vector_index");
+    EXPECT_FALSE(tracker_.HasFiniteUpperBound(handle));
 
-    tracker_.RegisterUpperBound(CellDataType::VECTOR_INDEX, {200, 0});
-    EXPECT_TRUE(tracker_.HasFiniteUpperBound(CellDataType::VECTOR_INDEX));
+    handle = tracker_.Register("vector_index", {200, 0});
+    EXPECT_TRUE(tracker_.HasFiniteUpperBound(handle));
 
     // Now capping should apply.
-    auto d1 = tracker_.Reserve(CellDataType::VECTOR_INDEX, {300, 0});
+    auto d1 = tracker_.Reserve(handle, {300, 0});
     EXPECT_EQ(d1.memory_bytes, 200);
 }
 
 TEST_F(LoadingOverheadTrackerTest, UnregisteredTypeAutoCreatesUnlimited) {
-    auto d1 = tracker_.Reserve(CellDataType::SCALAR_FIELD, {500, 0});
+    auto handle = tracker_.EnsureRegistered("scalar_field");
+    auto d1 = tracker_.Reserve(handle, {500, 0});
     EXPECT_EQ(d1.memory_bytes, 500);
 
-    auto r1 = tracker_.Release(CellDataType::SCALAR_FIELD, {500, 0});
+    auto r1 = tracker_.Release(handle, {500, 0});
     EXPECT_EQ(r1.memory_bytes, 500);
 
-    EXPECT_FALSE(tracker_.HasFiniteUpperBound(CellDataType::SCALAR_FIELD));
+    EXPECT_FALSE(tracker_.HasFiniteUpperBound(handle));
 }
 
 TEST_F(LoadingOverheadTrackerTest, UBChangesMidFlight) {
-    tracker_.RegisterUpperBound(CellDataType::VECTOR_INDEX, {200, 0});
+    auto handle = tracker_.Register("vector_index", {200, 0});
 
     // Reserve 3x100 under UB=200: dlist gets 100+100+0 = 200
-    auto d1 = tracker_.Reserve(CellDataType::VECTOR_INDEX, {100, 0});
+    auto d1 = tracker_.Reserve(handle, {100, 0});
     EXPECT_EQ(d1.memory_bytes, 100);
-    auto d2 = tracker_.Reserve(CellDataType::VECTOR_INDEX, {100, 0});
+    auto d2 = tracker_.Reserve(handle, {100, 0});
     EXPECT_EQ(d2.memory_bytes, 100);
-    auto d3 = tracker_.Reserve(CellDataType::VECTOR_INDEX, {100, 0});
+    auto d3 = tracker_.Reserve(handle, {100, 0});
     EXPECT_EQ(d3.memory_bytes, 0);
 
     int64_t total_reserved = d1.memory_bytes + d2.memory_bytes + d3.memory_bytes;
     EXPECT_EQ(total_reserved, 200);
 
     // UB changes to 400
-    tracker_.RegisterUpperBound(CellDataType::VECTOR_INDEX, {400, 0});
+    handle = tracker_.Register("vector_index", {400, 0});
 
     // Release all 3: should release exactly 200 total
-    auto r1 = tracker_.Release(CellDataType::VECTOR_INDEX, {100, 0});
+    auto r1 = tracker_.Release(handle, {100, 0});
     EXPECT_EQ(r1.memory_bytes, 0);
-    auto r2 = tracker_.Release(CellDataType::VECTOR_INDEX, {100, 0});
+    auto r2 = tracker_.Release(handle, {100, 0});
     EXPECT_EQ(r2.memory_bytes, 100);
-    auto r3 = tracker_.Release(CellDataType::VECTOR_INDEX, {100, 0});
+    auto r3 = tracker_.Release(handle, {100, 0});
     EXPECT_EQ(r3.memory_bytes, 100);
 
     int64_t total_released = r1.memory_bytes + r2.memory_bytes + r3.memory_bytes;
@@ -263,24 +268,25 @@ TEST_F(LoadingOverheadTrackerTest, UBChangesMidFlight) {
 }
 
 TEST_F(LoadingOverheadTrackerTest, UBDecreasesFromUnlimitedMidFlight) {
-    auto d1 = tracker_.Reserve(CellDataType::VECTOR_INDEX, {1000, 0});
+    auto handle = tracker_.EnsureRegistered("vector_index");
+    auto d1 = tracker_.Reserve(handle, {1000, 0});
     EXPECT_EQ(d1.memory_bytes, 1000);
-    auto d2 = tracker_.Reserve(CellDataType::VECTOR_INDEX, {1000, 0});
+    auto d2 = tracker_.Reserve(handle, {1000, 0});
     EXPECT_EQ(d2.memory_bytes, 1000);
 
     // Now register finite UB=200
-    tracker_.RegisterUpperBound(CellDataType::VECTOR_INDEX, {200, 0});
+    handle = tracker_.Register("vector_index", {200, 0});
 
     // Further reserves should be capped
-    auto d3 = tracker_.Reserve(CellDataType::VECTOR_INDEX, {100, 0});
+    auto d3 = tracker_.Reserve(handle, {100, 0});
     EXPECT_EQ(d3.memory_bytes, 0);
 
     // Release all 3: should release exactly 2000
-    auto r1 = tracker_.Release(CellDataType::VECTOR_INDEX, {1000, 0});
+    auto r1 = tracker_.Release(handle, {1000, 0});
     EXPECT_EQ(r1.memory_bytes, 1800);
-    auto r2 = tracker_.Release(CellDataType::VECTOR_INDEX, {1000, 0});
+    auto r2 = tracker_.Release(handle, {1000, 0});
     EXPECT_EQ(r2.memory_bytes, 100);
-    auto r3 = tracker_.Release(CellDataType::VECTOR_INDEX, {100, 0});
+    auto r3 = tracker_.Release(handle, {100, 0});
     EXPECT_EQ(r3.memory_bytes, 100);
 
     int64_t total_reserved = d1.memory_bytes + d2.memory_bytes + d3.memory_bytes;
@@ -290,10 +296,11 @@ TEST_F(LoadingOverheadTrackerTest, UBDecreasesFromUnlimitedMidFlight) {
 }
 
 TEST_F(LoadingOverheadTrackerTest, GetUpperBound) {
-    EXPECT_EQ(tracker_.GetUpperBound(CellDataType::VECTOR_INDEX), LoadingOverheadTracker::kUnlimited);
+    auto handle = tracker_.EnsureRegistered("vector_index");
+    EXPECT_EQ(tracker_.GetUpperBound(handle), LoadingOverheadTracker::kUnlimited);
 
-    tracker_.RegisterUpperBound(CellDataType::VECTOR_INDEX, {200, 100});
-    auto ub = tracker_.GetUpperBound(CellDataType::VECTOR_INDEX);
+    handle = tracker_.Register("vector_index", {200, 100});
+    auto ub = tracker_.GetUpperBound(handle);
     EXPECT_EQ(ub.memory_bytes, 200);
     EXPECT_EQ(ub.file_bytes, 100);
 }


### PR DESCRIPTION
Move tracker Reserve/Release calls inside DList's list_mtx_ lock,
making tracker state updates atomic with DList resource reservation.
This eliminates the TOCTOU race where a failed DList reservation
could cause tracker/DList accounting divergence under concurrency.

Key changes:
- DList holds shared_ptr<LoadingOverheadTracker>, set via SetLoadingOverheadTracker()
- New DList overloads: ReserveLoadingResourceWithTimeout(loaded, overhead, handle, ...)
  returns SemiFuture<ResourceUsage> (zero = failure, non-zero = actual reserved)
- ReleaseLoadingResource(loaded, overhead, handle) releases atomically
- LoadingOverheadTracker uses string-based group registration returning uint64_t
  handle for O(1) hot-path lookup; translator controls grouping via Meta
- CacheSlot no longer calls tracker directly, only passes overhead_handle_ to DList
- Manager/CacheSlot tracker pointer replaced with shared_ptr (fixes UAF risk)
- Translator::Meta gains loading_overhead_group field for custom grouping
- WaitingRequest carries overhead_handle for deferred fulfillment