### PR TITLE
Update Makefile and README

### DIFF
--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -46,13 +46,8 @@ jobs:
           conan profile detect --force \
           && conan remote add default-conan-local2 https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local2 --force
       - name: Build & Run
-        env:
-          CONAN_ARGS: '-o &:with_ut=True -o &:with_asan=True -s compiler.version=12 -s compiler.cppstd=20 -s build_type=Release -of .'
         run: |
-          mkdir build && cd build \
-          && conan install .. --build=missing $CONAN_ARGS \
-          && conan build .. $CONAN_ARGS \
-          && ./test/test_cachinglayer/cachinglayer_test && ./test/all_tests
+          make test BUILD_TYPE=Release CONAN_EXTRA='-o \&:with_ut=True -o \&:with_asan=True -s compiler.version=12 -s compiler.cppstd=20'
       - name: Save Conan Packages
         uses: actions/cache/save@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 BUILD_DIR     := build
 BUILD_TYPE    := Release
+CONAN_EXTRA   ?=
 CMAKE_EXTRA   ?=
 NPROC         := $(shell sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 4)
 UNAME_S       := $(shell uname -s)
@@ -27,7 +28,9 @@ conan: deps
 	$(SDKROOT_ENV) \
 	conan install . --build=missing \
 		-s build_type=$(BUILD_TYPE) \
-		-of $(BUILD_DIR)
+		-c tools.build:jobs=$(NPROC) \
+		-of $(BUILD_DIR) \
+		$(CONAN_EXTRA)
 
 configure: conan
 	cmake -S . -B $(BUILD_DIR) \
@@ -42,7 +45,7 @@ build: configure
 test: CMAKE_EXTRA += -DWITH_COMMON_UT=ON
 test: configure
 	cmake --build $(BUILD_DIR) -j$(NPROC)
-	ctest --test-dir $(BUILD_DIR) --output-on-failure
+	. $(BUILD_DIR)/conanrun.sh && ctest --test-dir $(BUILD_DIR) --output-on-failure
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -16,14 +16,40 @@ Milvus Common is a core component library that serves as a bridge between Milvus
 
 ## Build from source
 
+### Prepare
+
 ```
 pip install conan==2.25.1
 conan profile detect
 conan remote add default-conan-local2 https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local2
-mkdir build && cd build
-conan install .. --build=missing -o "&:with_ut=True" -s compiler.cppstd=17 -s build_type=Release -of .
-conan build .. -of .
+```
 
-# run ut
-./test/test_cachinglayer/cachinglayer_test
+### Build
+```
+make
+```
+
+Note: If your Conan profile defaults to a lower C++ standard, pass `CONAN_EXTRA="-s compiler.cppstd=gnu20"` to satisfy dependencies that require C++20.
+
+```
+make CONAN_EXTRA="-s compiler.cppstd=gnu20"
+```
+
+Useful Makefile variables:
+
+- `BUILD_TYPE`: CMake/Conan build type, default `Release`.
+- `CONAN_EXTRA`: extra arguments passed to `conan install`, for example `-s compiler.cppstd=gnu20`.
+- `CMAKE_EXTRA`: extra arguments passed to `cmake -S . -B build`, for example `-DWITH_COMMON_UT=ON`.
+- `NPROC`: parallel job count for Conan dependency builds and CMake builds.
+
+Example:
+
+```
+make BUILD_TYPE=Release CONAN_EXTRA="-s compiler.cppstd=gnu20" CMAKE_EXTRA="-DWITH_COMMON_UT=ON" NPROC=4
+```
+
+### Run test
+
+```
+make test
 ```


### PR DESCRIPTION
If your Conan profile defaults to a lower C++ standard(cppstd=17 or cppstd=gnu17) , then you will get compile errors since it requires minimum_cpp_standard=20. 
Now we add an option "CONAN_EXTRA" to pass the cppstd to conan.
And the "NPROC" is also passed to conan so that we can control the cpu usage for conan during compiling.
This pr also updated the README