### PR TITLE
Tune search OMP setter for direct HNSW

### DIFF
--- a/include/knowhere/thread_pool.h
+++ b/include/knowhere/thread_pool.h
@@ -223,10 +223,11 @@ class ThreadPool {
     class ScopedSearchOmpSetter {
         int omp_before;
 #ifdef OPENBLAS_OS_LINUX
+        bool set_blas_threads;
         int blas_thread_before;
 #endif
      public:
-        explicit ScopedSearchOmpSetter(int num_threads = 1);
+        explicit ScopedSearchOmpSetter(int num_threads = 1, bool set_blas_threads = true);
 
         ~ScopedSearchOmpSetter();
     };

--- a/src/knowhere/thread_pool.cc
+++ b/src/knowhere/thread_pool.cc
@@ -187,18 +187,24 @@ ThreadPool::ScopedBuildOmpSetter::~ScopedBuildOmpSetter() {
     omp_set_num_threads(omp_before);
 }
 
-ThreadPool::ScopedSearchOmpSetter::ScopedSearchOmpSetter(int num_threads) {
-    omp_before = (search_pool_ ? search_pool_->size() : omp_get_max_threads());
+ThreadPool::ScopedSearchOmpSetter::ScopedSearchOmpSetter(int num_threads, bool set_blas_threads_) {
+    omp_before = omp_get_max_threads();
 #ifdef OPENBLAS_OS_LINUX
+    set_blas_threads = set_blas_threads_;
     blas_thread_before = openblas_get_num_threads();
-    openblas_set_num_threads(1);
+    if (set_blas_threads) {
+        openblas_set_num_threads(1);
+    }
 #endif
-    omp_set_num_threads(num_threads <= 0 ? omp_before : num_threads);
+    const auto omp_target = num_threads <= 0 ? omp_before : num_threads;
+    omp_set_num_threads(omp_target);
 }
 
 ThreadPool::ScopedSearchOmpSetter::~ScopedSearchOmpSetter() {
 #ifdef OPENBLAS_OS_LINUX
-    openblas_set_num_threads(blas_thread_before);
+    if (set_blas_threads) {
+        openblas_set_num_threads(blas_thread_before);
+    }
 #endif
     omp_set_num_threads(omp_before);
 }


### PR DESCRIPTION
This updates `ThreadPool::ScopedSearchOmpSetter` so callers can choose whether to also change OpenBLAS thread settings.

For direct HNSW search execution, the caller may need to clamp OpenMP search parallelism without repeatedly changing the global OpenBLAS thread count. The default behavior is preserved by keeping `set_blas_threads=true`.

Changes:
- Store and restore the actual previous OpenMP max thread count.
- Add `set_blas_threads` parameter, defaulting to `true`.
- Only call `openblas_set_num_threads` when `set_blas_threads` is enabled.

Validation:
- Built and tested in the Milvus HNSW search-pool bypass experiment.
- Used by the follow-up Knowhere direct HNSW path to avoid unnecessary OpenBLAS global thread updates.
