### PR TITLE
Add thread-safe active thread pool stats

### DIFF
--- a/include/knowhere/thread_pool.h
+++ b/include/knowhere/thread_pool.h
@@ -200,6 +200,15 @@ class ThreadPool {
     static size_t
     GetFetchThreadPoolPendingTaskCount();
 
+    static size_t
+    GetGlobalBuildThreadPoolActiveThreadCount();
+
+    static size_t
+    GetGlobalSearchThreadPoolActiveThreadCount();
+
+    static size_t
+    GetGlobalFetchThreadPoolActiveThreadCount();
+
     static std::shared_ptr<ThreadPool>
     GetGlobalBuildThreadPool();
 

--- a/src/knowhere/thread_pool.cc
+++ b/src/knowhere/thread_pool.cc
@@ -146,6 +146,30 @@ ThreadPool::GetFetchThreadPoolPendingTaskCount() {
     return ThreadPool::GetGlobalFetchThreadPool()->GetPendingTaskCount();
 }
 
+size_t
+ThreadPool::GetGlobalBuildThreadPoolActiveThreadCount() {
+    std::lock_guard<std::mutex> lock(build_pool_mutex_);
+    return build_pool_ == nullptr
+               ? 0
+               : build_pool_->GetPool().getPoolStats().activeThreadCount;
+}
+
+size_t
+ThreadPool::GetGlobalSearchThreadPoolActiveThreadCount() {
+    std::lock_guard<std::mutex> lock(search_pool_mutex_);
+    return search_pool_ == nullptr
+               ? 0
+               : search_pool_->GetPool().getPoolStats().activeThreadCount;
+}
+
+size_t
+ThreadPool::GetGlobalFetchThreadPoolActiveThreadCount() {
+    std::lock_guard<std::mutex> lock(fetch_object_pool_mutex_);
+    return fetch_object_pool_ == nullptr
+               ? 0
+               : fetch_object_pool_->GetPool().getPoolStats().activeThreadCount;
+}
+
 std::shared_ptr<ThreadPool>
 ThreadPool::GetGlobalBuildThreadPool() {
     if (build_pool_ == nullptr) {


### PR DESCRIPTION
## What

Add thread-safe APIs to read active worker counts from the global Knowhere build, search, and fetch thread pools.

## Why

Milvus needs to expose C++ thread pool active worker metrics without directly reading the global thread pool shared_ptrs from outside milvus-common. These helpers reuse the existing per-pool mutexes and return 0 when the pool is not initialized.

## Changes

- Add GetGlobalBuildThreadPoolActiveThreadCount()
- Add GetGlobalSearchThreadPoolActiveThreadCount()
- Add GetGlobalFetchThreadPoolActiveThreadCount()
- Guard each read with the corresponding global pool mutex