### PR TITLE
fix: Undefined symbols in milvus::tracer::AutoSpan::AutoSpan

### DIFF
--- a/include/common/Tracer.h
+++ b/include/common/Tracer.h
@@ -21,10 +21,12 @@
 #include "opentelemetry/trace/span_id.h"
 #include "opentelemetry/trace/trace_id.h"
 
-namespace opentelemetry::trace {
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace {
 class Span;
 class Tracer;
-}  // namespace opentelemetry::trace
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE
 
 #define TRACE_SERVICE_SEGCORE "segcore"
 

--- a/test/TracerTest.cpp
+++ b/test/TracerTest.cpp
@@ -57,6 +57,12 @@ TEST(Tracer, Span) {
     delete[] ctx->spanID;
 }
 
+TEST(Tracer, AutoSpanParentConstructorUsesHeaderDeclaredSpanType) {
+    std::shared_ptr<milvus::tracer::trace::Span> parent;
+    AutoSpan span("header_abi_parent", parent, false);
+    ASSERT_NE(span.GetSpan(), nullptr);
+}
+
 TEST(Tracer, OwnedTraceSnapshotCopiesBytes) {
     uint8_t trace_id[16]{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
                          0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10};


### PR DESCRIPTION
after: https://github.com/zilliztech/milvus-common/pull/93

build with milvus failed with stack:
```
Undefined symbols for architecture arm64:
  "milvus::tracer::AutoSpan::AutoSpan(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<opentelemetry::trace::Span> const&, bool)", referenced from:
      milvus::index::BitmapIndex<bool>::In(unsigned long, bool const*) in BitmapIndex.cpp.o
      milvus::index::BitmapIndex<bool>::IsNull() in BitmapIndex.cpp.o
      milvus::index::BitmapIndex<bool>::IsNotNull() in BitmapIndex.cpp.o
      milvus::index::BitmapIndex<bool>::NotIn(unsigned long, bool const*) in BitmapIndex.cpp.o
      milvus::index::BitmapIndex<bool>::Reverse_Lookup(unsigned long) const in BitmapIndex.cpp.o
      milvus::index::BitmapIndex<signed char>::In(unsigned long, signed char const*) in BitmapIndex.cpp.o
      milvus::index::BitmapIndex<signed char>::IsNull() in BitmapIndex.cpp.o
      ...
ld: symbol(s) not found for architecture arm64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

Pre-defined autospan will got this error