### PR TITLE
enhance: add retriable StorageTransientError(2045) error code

### DIFF
--- a/include/common/EasyAssert.h
+++ b/include/common/EasyAssert.h
@@ -71,8 +71,16 @@ enum ErrorCode {
     TextIndexNotFound = 2041,
     InvalidParameter = 2042,
     InsufficientResource = 2043,
-    // milvus-storage related error code
+    // milvus-storage related error codes. These two are a *pair* of generic
+    // storage fallbacks, each carrying exactly one retry verdict, and must never
+    // be conflated:
+    //   StorageError          (2044) -> permanent / non-retriable fallback.
+    //   StorageTransientError (2045) -> retriable storage transient fallback
+    //       (object-storage IO / throttling / timeout etc). A transient storage
+    //       failure must map here, NOT to StorageError, otherwise a retriable
+    //       IO error becomes non-retriable and regresses availability.
     StorageError = 2044,
+    StorageTransientError = 2045,
 
     KnowhereError = 2099,
 };


### PR DESCRIPTION
## What

Add a retriable storage transient fallback error code `StorageTransientError = 2045`, paired with the existing permanent `StorageError = 2044`, to `enum ErrorCode` in `include/common/EasyAssert.h`.

## Why

Producers (milvus-storage) and the milvus segcore boundary need a generic **retriable** storage code so a transient object-storage IO / throttling / timeout failure stays retriable, instead of collapsing into the non-retriable `StorageError`. The two codes are a pair — each carries exactly one retry verdict and they must never be conflated.

## Part of

The segcore error-classification effort: milvus-io/milvus#50903 (design). Consumed by the milvus-storage `ToSegcoreErrorCode` mapping and the milvus segcore code table.
