### PR TITLE
Add const char span name overloads

### DIFF
--- a/include/common/Tracer.h
+++ b/include/common/Tracer.h
@@ -114,7 +114,13 @@ std::shared_ptr<trace::Span>
 StartSpan(const std::string& name, TraceContext* ctx = nullptr);
 
 std::shared_ptr<trace::Span>
+StartSpan(const char* name, TraceContext* ctx = nullptr);
+
+std::shared_ptr<trace::Span>
 StartSpan(const std::string& name, const std::shared_ptr<trace::Span>& span);
+
+std::shared_ptr<trace::Span>
+StartSpan(const char* name, const std::shared_ptr<trace::Span>& span);
 
 void
 SetRootSpan(std::shared_ptr<trace::Span> span);
@@ -163,6 +169,12 @@ class ScopedSpan {
         }
     }
 
+    ScopedSpan(const char* name, const SpanPtr& parent) {
+        if (parent != nullptr && IsTraceEnabled()) {
+            span_ = StartSpan(name, parent);
+        }
+    }
+
     ScopedSpan(const ScopedSpan&) = delete;
     ScopedSpan&
     operator=(const ScopedSpan&) = delete;
@@ -190,6 +202,11 @@ class ScopedSpan {
 
     ScopedSpan
     StartChild(const std::string& name) const {
+        return ScopedSpan(name, span_);
+    }
+
+    ScopedSpan
+    StartChild(const char* name) const {
         return ScopedSpan(name, span_);
     }
 

--- a/src/common/Tracer.cpp
+++ b/src/common/Tracer.cpp
@@ -167,6 +167,23 @@ StartSpan(const std::string& name, TraceContext* parentCtx) {
 }
 
 std::shared_ptr<trace::Span>
+StartSpan(const char* name, TraceContext* parentCtx) {
+    if (!IsTraceEnabled()) {
+        return noop_span;
+    }
+    trace::StartSpanOptions opts;
+    if (parentCtx != nullptr && parentCtx->traceID != nullptr && parentCtx->spanID != nullptr) {
+        if (EmptyTraceID(parentCtx) || EmptySpanID(parentCtx)) {
+            return noop_trace_provider->GetTracer("noop")->StartSpan("noop");
+        }
+        opts.parent = trace::SpanContext(trace::TraceId({parentCtx->traceID, trace::TraceId::kSize}),
+                                         trace::SpanId({parentCtx->spanID, trace::SpanId::kSize}),
+                                         trace::TraceFlags(parentCtx->traceFlags), true);
+    }
+    return GetTracer()->StartSpan(nostd::string_view{name}, opts);
+}
+
+std::shared_ptr<trace::Span>
 StartSpan(const std::string& name, const std::shared_ptr<trace::Span>& span) {
     if (!IsTraceEnabled()) {
         return noop_span;
@@ -176,6 +193,18 @@ StartSpan(const std::string& name, const std::shared_ptr<trace::Span>& span) {
         opts.parent = span->GetContext();
     }
     return GetTracer()->StartSpan(name, opts);
+}
+
+std::shared_ptr<trace::Span>
+StartSpan(const char* name, const std::shared_ptr<trace::Span>& span) {
+    if (!IsTraceEnabled()) {
+        return noop_span;
+    }
+    trace::StartSpanOptions opts;
+    if (span != nullptr) {
+        opts.parent = span->GetContext();
+    }
+    return GetTracer()->StartSpan(nostd::string_view{name}, opts);
 }
 
 thread_local std::shared_ptr<trace::Span> local_span;


### PR DESCRIPTION
## Summary

- add `const char*` overloads for `StartSpan`, `ScopedSpan`, and `ScopedSpan::StartChild`
- let string-literal span names avoid temporary `std::string` construction before tracing-enabled checks
- keep existing `std::string` span-name APIs unchanged

## Context

Cardinal PR https://github.com/zilliztech/cardinal/pull/865 uses `milvus::tracer::ScopedSpan` with string-literal span names in graph search paths. A review on that PR asks for milvus-common overloads so those literals do not need to materialize temporary `std::string` objects before the helper can check whether tracing is active.

## Verification

Not run locally. This is intended to be validated by upstream CI.