### PR TITLE
enhance: track loading overhead per dimension

### DIFF
--- a/include/cachinglayer/CacheSlot.h
+++ b/include/cachinglayer/CacheSlot.h
@@ -83,7 +83,7 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
         // Register after all potentially-throwing operations, so that if the constructor
         // fails, we don't leak a ref_count (destructor won't run for incomplete objects).
         if (auto& lo = translator_->meta()->loading_overhead) {
-            overhead_handle_ = dlist_->RegisterLoadingOverhead(lo->group, lo->upper_bound);
+            overhead_handle_ = dlist_->RegisterLoadingOverhead(*lo);
         }
     }
 
@@ -436,9 +436,9 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
     void
     RunLoad(OpContext* ctx, std::unordered_set<cid_t>&& cids, std::chrono::milliseconds timeout) {
         // loaded_resource: the estimated final resource usage (from .first), reserved unconditionally.
-        // loading_overhead: the estimated temporary overhead during loading (from .second),
-        //   capped at per-type UB via LoadingOverheadTracker. The tracker returns the incremental
-        //   delta to reserve from DList, so total loading in DList = min(sum, UB) per type.
+        // loading_overhead: the estimated temporary overhead during loading (from .second).
+        //   Configured dimensions are group-capped by LoadingOverheadTracker; omitted dimensions
+        //   pass through unchanged. The tracker returns the combined incremental DList delta.
         std::vector<cid_t> loading_cids;
         try {
             auto start = std::chrono::steady_clock::now();
@@ -484,7 +484,8 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
             }
 
             // loaded_resource is reserved unconditionally from DList (no capping).
-            // loading_overhead goes through the tracker: returns delta = change in min(sum, UB).
+            // loading_overhead goes through the tracker: configured dimensions return the change
+            // in min(sum, UB), while omitted dimensions return their full overhead.
             auto loaded_resource = essential_loaded_resource + bonus_loaded_resource;
             auto loading_overhead = essential_loading_overhead + bonus_loading_overhead;
 

--- a/include/cachinglayer/LoadingOverhead.h
+++ b/include/cachinglayer/LoadingOverhead.h
@@ -14,6 +14,9 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <utility>
+
+#include "cachinglayer/Utils.h"
 
 namespace milvus::cachinglayer {
 
@@ -25,6 +28,19 @@ struct LoadingOverheadDimensionConfig {
 // A missing dimension is not group-capped. Its loading overhead passes through
 // unchanged and is still checked against the DList resource limit.
 struct LoadingOverheadConfig {
+    LoadingOverheadConfig() = default;
+
+    LoadingOverheadConfig(std::optional<LoadingOverheadDimensionConfig> memory,
+                          std::optional<LoadingOverheadDimensionConfig> file)
+        : memory(std::move(memory)), file(std::move(file)) {
+    }
+
+    // Compatibility entry point for callers using the original shared-group config.
+    LoadingOverheadConfig(const ResourceUsage& upper_bound, std::string group)
+        : memory(LoadingOverheadDimensionConfig{upper_bound.memory_bytes, group}),
+          file(LoadingOverheadDimensionConfig{upper_bound.file_bytes, std::move(group)}) {
+    }
+
     std::optional<LoadingOverheadDimensionConfig> memory;
     std::optional<LoadingOverheadDimensionConfig> file;
 };

--- a/include/cachinglayer/LoadingOverhead.h
+++ b/include/cachinglayer/LoadingOverhead.h
@@ -1,0 +1,32 @@
+// Copyright (C) 2019-2026 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace milvus::cachinglayer {
+
+struct LoadingOverheadDimensionConfig {
+    int64_t upper_bound;
+    std::string group;
+};
+
+// A missing dimension is not group-capped. Its loading overhead passes through
+// unchanged and is still checked against the DList resource limit.
+struct LoadingOverheadConfig {
+    std::optional<LoadingOverheadDimensionConfig> memory;
+    std::optional<LoadingOverheadDimensionConfig> file;
+};
+
+}  // namespace milvus::cachinglayer

--- a/include/cachinglayer/LoadingOverheadTracker.h
+++ b/include/cachinglayer/LoadingOverheadTracker.h
@@ -30,7 +30,8 @@ namespace milvus::cachinglayer {
 //
 // The total loading overhead reserved from DList for each configured dimension is capped:
 //   DList dimension reservation = min(sum_of_overhead, dimension_UB)
-// An unconfigured dimension passes through unchanged.
+// An unconfigured dimension passes through unchanged. INT64_MAX is an explicit
+// unlimited upper bound; re-registering a group can only increase its upper bound.
 //
 // Each Reserve/Release call returns the incremental delta to apply to DList.
 // The tracker directly tracks `overhead_reserved` (actual amount of overhead currently
@@ -157,11 +158,7 @@ class LoadingOverheadTracker {
         if (it != name_to_handle.end()) {
             auto& state = dimension_group_state_[it->second];
             state.ref_count++;
-            if (state.upper_bound == std::numeric_limits<int64_t>::max()) {
-                state.upper_bound = config.upper_bound;
-                LOG_INFO("[MCL] LoadingOverheadTracker set {} UB for group '{}' (handle {}, refs={}): {}", dimension,
-                         config.group, it->second, state.ref_count, config.upper_bound);
-            } else if (state.upper_bound < config.upper_bound) {
+            if (state.upper_bound < config.upper_bound) {
                 LOG_WARN(
                     "[MCL] LoadingOverheadTracker {} UB mismatch for group '{}' (handle {}): existing={}, new={}. "
                     "Taking max.",

--- a/include/cachinglayer/LoadingOverheadTracker.h
+++ b/include/cachinglayer/LoadingOverheadTracker.h
@@ -12,28 +12,32 @@
 #pragma once
 
 #include <algorithm>
+#include <limits>
 #include <mutex>
 #include <string>
 #include <unordered_map>
 
+#include "cachinglayer/LoadingOverhead.h"
 #include "cachinglayer/Utils.h"
 #include "log/Log.h"
 
 namespace milvus::cachinglayer {
 
-// Manages per-group loading overhead reservation with an overhead upper bound (UB).
+// Manages per-dimension, per-group loading overhead reservation with an upper bound (UB).
 //
-// Groups are identified by string keys at registration time. Registration returns
-// a uint64_t handle for O(1) lookup on the hot path (Reserve/Release).
+// Memory and file groups are independent even when they use the same string key.
+// Registration returns a composite uint64_t handle for O(1) lookup on the hot path.
 //
-// The total loading overhead reserved from DList for a given group is capped at UB:
-//   DList loading overhead reservation = min(sum_of_overhead, UB)
+// The total loading overhead reserved from DList for each configured dimension is capped:
+//   DList dimension reservation = min(sum_of_overhead, dimension_UB)
+// An unconfigured dimension passes through unchanged.
 //
 // Each Reserve/Release call returns the incremental delta to apply to DList.
 // The tracker directly tracks `overhead_reserved` (actual amount of overhead currently
 // reserved in DList) to ensure correctness.
 //
-// By default, groups are registered with kUnlimited UB, preserving original behavior.
+// The compatibility Register overload configures both dimensions. A missing
+// dimension in LoadingOverheadConfig preserves pass-through behavior.
 class LoadingOverheadTracker {
  public:
     static inline const ResourceUsage kUnlimited{std::numeric_limits<int64_t>::max(),
@@ -41,58 +45,46 @@ class LoadingOverheadTracker {
 
     static constexpr uint64_t kInvalidHandle = 0;
 
-    // Register a group with an upper bound. Returns a handle for hot-path use.
-    // If the group already exists with a finite UB, takes the larger of the two per dimension.
-    // If previously registered with kUnlimited, replaces with the given UB.
-    // Each Register increments a ref count; call Unregister to decrement.
+    uint64_t
+    Register(const LoadingOverheadConfig& config) {
+        std::lock_guard<std::mutex> lock(mtx_);
+        RegistrationState registration;
+        if (config.memory.has_value()) {
+            registration.memory_group_handle =
+                registerDimensionGroup(memory_name_to_group_handle_, config.memory.value(), "memory");
+        }
+        if (config.file.has_value()) {
+            registration.file_group_handle =
+                registerDimensionGroup(file_name_to_group_handle_, config.file.value(), "file");
+        }
+
+        auto handle = next_registration_handle_++;
+        registration_state_[handle] = registration;
+        return handle;
+    }
+
+    // Compatibility entry point. The two dimensions use independent group state.
     uint64_t
     Register(const std::string& group, const ResourceUsage& upper_bound) {
-        std::lock_guard<std::mutex> lock(mtx_);
-        auto it = name_to_handle_.find(group);
-        if (it != name_to_handle_.end()) {
-            auto& state = handle_state_[it->second];
-            state.ref_count++;
-            if (state.upper_bound == kUnlimited) {
-                state.upper_bound = upper_bound;
-                LOG_INFO("[MCL] LoadingOverheadTracker set UB for group '{}' (handle {}, refs={}): {}", group,
-                         it->second, state.ref_count, upper_bound.ToString());
-            } else if (state.upper_bound.memory_bytes < upper_bound.memory_bytes ||
-                       state.upper_bound.file_bytes < upper_bound.file_bytes) {
-                LOG_WARN(
-                    "[MCL] LoadingOverheadTracker UB mismatch for group '{}' (handle {}): existing={}, new={}. "
-                    "Taking max per dimension.",
-                    group, it->second, state.upper_bound.ToString(), upper_bound.ToString());
-                state.upper_bound.memory_bytes = std::max(state.upper_bound.memory_bytes, upper_bound.memory_bytes);
-                state.upper_bound.file_bytes = std::max(state.upper_bound.file_bytes, upper_bound.file_bytes);
-            } else {
-                LOG_DEBUG("[MCL] LoadingOverheadTracker re-registered group '{}' (handle {}, refs={}), UB unchanged",
-                          group, it->second, state.ref_count);
-            }
-            return it->second;
-        }
-        auto handle = next_handle_++;
-        name_to_handle_[group] = handle;
-        handle_state_[handle] = GroupState{upper_bound, {}, {}, 1, group};
-        LOG_INFO("[MCL] LoadingOverheadTracker registered group '{}' (handle {}, refs=1): UB={}", group, handle,
-                 upper_bound.ToString());
-        return handle;
+        return Register(LoadingOverheadConfig{LoadingOverheadDimensionConfig{upper_bound.memory_bytes, group},
+                                              LoadingOverheadDimensionConfig{upper_bound.file_bytes, group}});
     }
 
     // Called before loading. Returns the delta to reserve from DList for loading overhead.
     ResourceUsage
     Reserve(uint64_t handle, const ResourceUsage& loading_overhead) {
         std::lock_guard<std::mutex> lock(mtx_);
-        auto it = handle_state_.find(handle);
-        if (it == handle_state_.end()) {
+        auto it = registration_state_.find(handle);
+        if (it == registration_state_.end()) {
             return loading_overhead;
         }
-        auto& state = it->second;
-        state.sum_of_overhead += loading_overhead;
-        auto target = cappedAmount(state.sum_of_overhead, state.upper_bound);
-        auto delta = target - state.overhead_reserved;
-        delta.memory_bytes = std::max(delta.memory_bytes, int64_t{0});
-        delta.file_bytes = std::max(delta.file_bytes, int64_t{0});
-        state.overhead_reserved += delta;
+        auto delta = loading_overhead;
+        if (it->second.memory_group_handle != kInvalidHandle) {
+            delta.memory_bytes = reserveDimension(it->second.memory_group_handle, loading_overhead.memory_bytes);
+        }
+        if (it->second.file_group_handle != kInvalidHandle) {
+            delta.file_bytes = reserveDimension(it->second.file_group_handle, loading_overhead.file_bytes);
+        }
         return delta;
     }
 
@@ -101,43 +93,30 @@ class LoadingOverheadTracker {
     ResourceUsage
     Release(uint64_t handle, const ResourceUsage& loading_overhead) {
         std::lock_guard<std::mutex> lock(mtx_);
-        auto it = handle_state_.find(handle);
-        if (it == handle_state_.end()) {
+        auto it = registration_state_.find(handle);
+        if (it == registration_state_.end()) {
             return loading_overhead;
         }
-        auto& state = it->second;
-        state.sum_of_overhead -= loading_overhead;
-        if (state.sum_of_overhead.memory_bytes < 0) {
-            LOG_ERROR("[MCL] LoadingOverheadTracker Release handle {}: sum_of_overhead.memory_bytes < 0", handle);
-            state.sum_of_overhead.memory_bytes = 0;
+        auto delta = loading_overhead;
+        if (it->second.memory_group_handle != kInvalidHandle) {
+            delta.memory_bytes = releaseDimension(it->second.memory_group_handle, loading_overhead.memory_bytes);
         }
-        if (state.sum_of_overhead.file_bytes < 0) {
-            LOG_ERROR("[MCL] LoadingOverheadTracker Release handle {}: sum_of_overhead.file_bytes < 0", handle);
-            state.sum_of_overhead.file_bytes = 0;
+        if (it->second.file_group_handle != kInvalidHandle) {
+            delta.file_bytes = releaseDimension(it->second.file_group_handle, loading_overhead.file_bytes);
         }
-        auto target = cappedAmount(state.sum_of_overhead, state.upper_bound);
-        auto delta = state.overhead_reserved - target;
-        delta.memory_bytes = std::max(delta.memory_bytes, int64_t{0});
-        delta.file_bytes = std::max(delta.file_bytes, int64_t{0});
-        state.overhead_reserved -= delta;
         return delta;
     }
 
     bool
     HasFiniteUpperBound(uint64_t handle) const {
         std::lock_guard<std::mutex> lock(mtx_);
-        auto it = handle_state_.find(handle);
-        return it != handle_state_.end() && !(it->second.upper_bound == kUnlimited);
+        return !(getUpperBoundLocked(handle) == kUnlimited);
     }
 
     ResourceUsage
     GetUpperBound(uint64_t handle) const {
         std::lock_guard<std::mutex> lock(mtx_);
-        auto it = handle_state_.find(handle);
-        if (it == handle_state_.end()) {
-            return kUnlimited;
-        }
-        return it->second.upper_bound;
+        return getUpperBoundLocked(handle);
     }
 
     // Decrement ref count for a group. When ref count reaches 0, the group is
@@ -148,8 +127,109 @@ class LoadingOverheadTracker {
             return;
         }
         std::lock_guard<std::mutex> lock(mtx_);
-        auto it = handle_state_.find(handle);
-        if (it == handle_state_.end()) {
+        auto it = registration_state_.find(handle);
+        if (it == registration_state_.end()) {
+            return;
+        }
+        unregisterDimensionGroup(memory_name_to_group_handle_, it->second.memory_group_handle, "memory");
+        unregisterDimensionGroup(file_name_to_group_handle_, it->second.file_group_handle, "file");
+        registration_state_.erase(it);
+    }
+
+ private:
+    struct DimensionGroupState {
+        int64_t upper_bound{0};
+        int64_t sum_of_overhead{0};
+        int64_t overhead_reserved{0};
+        uint64_t ref_count{0};
+        std::string group_name;
+    };
+
+    struct RegistrationState {
+        uint64_t memory_group_handle{kInvalidHandle};
+        uint64_t file_group_handle{kInvalidHandle};
+    };
+
+    uint64_t
+    registerDimensionGroup(std::unordered_map<std::string, uint64_t>& name_to_handle,
+                           const LoadingOverheadDimensionConfig& config, const char* dimension) {
+        auto it = name_to_handle.find(config.group);
+        if (it != name_to_handle.end()) {
+            auto& state = dimension_group_state_[it->second];
+            state.ref_count++;
+            if (state.upper_bound == std::numeric_limits<int64_t>::max()) {
+                state.upper_bound = config.upper_bound;
+                LOG_INFO("[MCL] LoadingOverheadTracker set {} UB for group '{}' (handle {}, refs={}): {}", dimension,
+                         config.group, it->second, state.ref_count, config.upper_bound);
+            } else if (state.upper_bound < config.upper_bound) {
+                LOG_WARN(
+                    "[MCL] LoadingOverheadTracker {} UB mismatch for group '{}' (handle {}): existing={}, new={}. "
+                    "Taking max.",
+                    dimension, config.group, it->second, state.upper_bound, config.upper_bound);
+                state.upper_bound = config.upper_bound;
+            } else {
+                LOG_DEBUG("[MCL] LoadingOverheadTracker re-registered {} group '{}' (handle {}, refs={}), UB unchanged",
+                          dimension, config.group, it->second, state.ref_count);
+            }
+            return it->second;
+        }
+
+        auto handle = next_group_handle_++;
+        name_to_handle[config.group] = handle;
+        dimension_group_state_[handle] = DimensionGroupState{config.upper_bound, 0, 0, 1, config.group};
+        LOG_INFO("[MCL] LoadingOverheadTracker registered {} group '{}' (handle {}, refs=1): UB={}", dimension,
+                 config.group, handle, config.upper_bound);
+        return handle;
+    }
+
+    int64_t
+    reserveDimension(uint64_t group_handle, int64_t overhead) {
+        auto& state = dimension_group_state_.at(group_handle);
+        state.sum_of_overhead += overhead;
+        auto target = std::min(std::max(state.sum_of_overhead, int64_t{0}), state.upper_bound);
+        auto delta = std::max(target - state.overhead_reserved, int64_t{0});
+        state.overhead_reserved += delta;
+        return delta;
+    }
+
+    int64_t
+    releaseDimension(uint64_t group_handle, int64_t overhead) {
+        auto& state = dimension_group_state_.at(group_handle);
+        state.sum_of_overhead -= overhead;
+        if (state.sum_of_overhead < 0) {
+            LOG_ERROR("[MCL] LoadingOverheadTracker Release group handle {}: sum_of_overhead < 0", group_handle);
+            state.sum_of_overhead = 0;
+        }
+        auto target = std::min(state.sum_of_overhead, state.upper_bound);
+        auto delta = std::max(state.overhead_reserved - target, int64_t{0});
+        state.overhead_reserved -= delta;
+        return delta;
+    }
+
+    ResourceUsage
+    getUpperBoundLocked(uint64_t registration_handle) const {
+        auto it = registration_state_.find(registration_handle);
+        if (it == registration_state_.end()) {
+            return kUnlimited;
+        }
+        ResourceUsage result = kUnlimited;
+        if (it->second.memory_group_handle != kInvalidHandle) {
+            result.memory_bytes = dimension_group_state_.at(it->second.memory_group_handle).upper_bound;
+        }
+        if (it->second.file_group_handle != kInvalidHandle) {
+            result.file_bytes = dimension_group_state_.at(it->second.file_group_handle).upper_bound;
+        }
+        return result;
+    }
+
+    void
+    unregisterDimensionGroup(std::unordered_map<std::string, uint64_t>& name_to_handle, uint64_t group_handle,
+                             const char* dimension) {
+        if (group_handle == kInvalidHandle) {
+            return;
+        }
+        auto it = dimension_group_state_.find(group_handle);
+        if (it == dimension_group_state_.end()) {
             return;
         }
         auto& state = it->second;
@@ -157,41 +237,29 @@ class LoadingOverheadTracker {
             state.ref_count--;
         }
         if (state.ref_count > 0) {
-            LOG_DEBUG("[MCL] LoadingOverheadTracker handle {} ref_count decremented to {}", handle, state.ref_count);
+            LOG_DEBUG("[MCL] LoadingOverheadTracker {} group handle {} ref_count decremented to {}", dimension,
+                      group_handle, state.ref_count);
             return;
         }
-        // ref_count == 0, unconditionally clean up.
-        // Log error if there are residual reservations — indicates a Reserve/Release pairing bug.
-        if (state.sum_of_overhead.AnyGTZero() || state.overhead_reserved.AnyGTZero()) {
+        if (state.sum_of_overhead > 0 || state.overhead_reserved > 0) {
             LOG_ERROR(
-                "[MCL] LoadingOverheadTracker handle {} ref_count=0 with residual reservations: "
+                "[MCL] LoadingOverheadTracker {} group handle {} ref_count=0 with residual reservations: "
                 "sum_of_overhead={}, overhead_reserved={}. Cleaning up anyway to avoid leak.",
-                handle, state.sum_of_overhead.ToString(), state.overhead_reserved.ToString());
+                dimension, group_handle, state.sum_of_overhead, state.overhead_reserved);
         }
-        LOG_INFO("[MCL] LoadingOverheadTracker unregistered group '{}' (handle {})", state.group_name, handle);
-        name_to_handle_.erase(state.group_name);
-        handle_state_.erase(it);
-    }
-
- private:
-    struct GroupState {
-        ResourceUsage upper_bound;
-        ResourceUsage sum_of_overhead;
-        ResourceUsage overhead_reserved;
-        uint64_t ref_count{0};
-        std::string group_name;
-    };
-
-    static ResourceUsage
-    cappedAmount(const ResourceUsage& sum, const ResourceUsage& ub) {
-        return {std::min(std::max(sum.memory_bytes, int64_t{0}), ub.memory_bytes),
-                std::min(std::max(sum.file_bytes, int64_t{0}), ub.file_bytes)};
+        LOG_INFO("[MCL] LoadingOverheadTracker unregistered {} group '{}' (handle {})", dimension, state.group_name,
+                 group_handle);
+        name_to_handle.erase(state.group_name);
+        dimension_group_state_.erase(it);
     }
 
     mutable std::mutex mtx_;
-    std::unordered_map<std::string, uint64_t> name_to_handle_;
-    std::unordered_map<uint64_t, GroupState> handle_state_;
-    uint64_t next_handle_{1};
+    std::unordered_map<std::string, uint64_t> memory_name_to_group_handle_;
+    std::unordered_map<std::string, uint64_t> file_name_to_group_handle_;
+    std::unordered_map<uint64_t, DimensionGroupState> dimension_group_state_;
+    std::unordered_map<uint64_t, RegistrationState> registration_state_;
+    uint64_t next_group_handle_{1};
+    uint64_t next_registration_handle_{1};
 };
 
 }  // namespace milvus::cachinglayer

--- a/include/cachinglayer/Translator.h
+++ b/include/cachinglayer/Translator.h
@@ -17,16 +17,12 @@
 #include <utility>
 #include <vector>
 
+#include "cachinglayer/LoadingOverhead.h"
 #include "cachinglayer/Utils.h"
 #include "common/OpContext.h"
 #include "common/common_type_c.h"
 
 namespace milvus::cachinglayer {
-
-struct LoadingOverheadConfig {
-    ResourceUsage upper_bound;
-    std::string group;
-};
 
 struct MetricAttribution {
     // Optional stable shard/channel label for attributed cache-slot disk usage metrics.
@@ -47,10 +43,9 @@ struct Meta {
     // Does not affect manual eviction.
     bool support_eviction;
     // Loading overhead configuration for this translator.
-    // When set, the total loading overhead across all CacheSlots sharing the same group
-    // is capped at upper_bound, preventing over-reservation when many concurrent
-    // loads happen. The real resource usage is bounded by loading_pool_size * cell_size.
-    // If not set, no capping is applied (existing behavior).
+    // Each configured resource dimension is capped across CacheSlots sharing its group.
+    // An omitted dimension passes through unchanged and remains subject to DList admission.
+    // If the whole config is not set, no capping is applied (existing behavior).
     std::optional<LoadingOverheadConfig> loading_overhead;
     std::optional<MetricAttribution> metric_attribution;
     explicit Meta(StorageType storage_type, CellIdMappingMode cell_id_mapping_mode, CellDataType cell_data_type,
@@ -81,9 +76,8 @@ class Translator {
     //   - loaded_usage (first): the final resource usage after the cell is fully loaded and in cache.
     //   - loading_overhead (second): the *temporary* resource usage during loading (e.g., preprocessing buffers),
     //     excluding the final loaded usage. This is the extra overhead that only exists during the loading phase.
-    // When loading_overhead_upper_bound is set in Meta, the total loading reservation across all CacheSlots
-    // of the same CellDataType is capped at that upper bound, since actual concurrent resource usage is
-    // bounded by loading_pool_size * cell_size.
+    // When a loading_overhead dimension is configured in Meta, the total reservation across all CacheSlots
+    // sharing that dimension's group is capped at its upper bound. Omitted dimensions pass through unchanged.
     // If a cell is about to be pinned and loaded, and there are not enough resource for it, EvictionManager
     // will try to evict some other cells to make space. Thus this estimation should generally be greater
     // than or equal to the actual size. If the estimation is smaller than the actual size, with insufficient

--- a/include/cachinglayer/lrucache/DList.h
+++ b/include/cachinglayer/lrucache/DList.h
@@ -76,6 +76,14 @@ class DList : public std::enable_shared_from_this<DList> {
     }
 
     uint64_t
+    RegisterLoadingOverhead(const LoadingOverheadConfig& config) {
+        if (loading_overhead_tracker_) {
+            return loading_overhead_tracker_->Register(config);
+        }
+        return LoadingOverheadTracker::kInvalidHandle;
+    }
+
+    uint64_t
     RegisterLoadingOverhead(const std::string& group, const ResourceUsage& upper_bound) {
         if (loading_overhead_tracker_) {
             return loading_overhead_tracker_->Register(group, upper_bound);

--- a/test/test_cachinglayer/test_cache_slot.cpp
+++ b/test/test_cachinglayer/test_cache_slot.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "cachinglayer/CacheSlot.h"
+#include "cachinglayer/LoadingOverhead.h"
 #include "cachinglayer/Metrics.h"
 #include "cachinglayer/Translator.h"
 #include "cachinglayer/Utils.h"
@@ -88,9 +89,9 @@ class MockTranslator : public Translator<TestCell> {
     estimated_byte_size_of_cell(cid_t cid) const override {
         auto it = cell_sizes_.find(cid);
         if (it != cell_sizes_.end()) {
-            return {{it->second, 0}, {loading_overhead_bytes_, 0}};
+            return {{it->second, 0}, loading_overhead_};
         }
-        return {{1, 0}, {loading_overhead_bytes_, 0}};
+        return {{1, 0}, loading_overhead_};
     }
 
     int64_t
@@ -185,11 +186,20 @@ class MockTranslator : public Translator<TestCell> {
     }
     void
     SetLoadingOverheadBytes(int64_t bytes) {
-        loading_overhead_bytes_ = bytes;
+        loading_overhead_ = {bytes, 0};
+    }
+    void
+    SetLoadingOverhead(ResourceUsage loading_overhead) {
+        loading_overhead_ = loading_overhead;
     }
     void
     SetLoadingOverheadConfig(const std::string& group, const ResourceUsage& upper_bound) {
-        meta_.loading_overhead = LoadingOverheadConfig{upper_bound, group};
+        meta_.loading_overhead = LoadingOverheadConfig{LoadingOverheadDimensionConfig{upper_bound.memory_bytes, group},
+                                                       LoadingOverheadDimensionConfig{upper_bound.file_bytes, group}};
+    }
+    void
+    SetLoadingOverheadConfig(LoadingOverheadConfig config) {
+        meta_.loading_overhead = std::move(config);
     }
     int
     GetCellsCallCount() const {
@@ -222,7 +232,7 @@ class MockTranslator : public Translator<TestCell> {
     std::unordered_map<cid_t, std::vector<cid_t>> extra_cids_;
     std::atomic<int> get_cells_call_count_ = 0;
     std::vector<std::vector<cid_t>> requested_cids_;
-    int64_t loading_overhead_bytes_ = 0;
+    ResourceUsage loading_overhead_{};
 
     // this class is not concurrent safe, so if for concurrent test, do not track usage
     bool for_concurrent_test_ = false;
@@ -2178,6 +2188,46 @@ TEST(CacheSlotTrackerTest, LoadingOverheadTrackerIntegration) {
     EXPECT_EQ(accessor2->get_cell_of(1)->data, 10);
 
     EXPECT_EQ(translator_ptr->GetCellsCallCount(), 2);
+}
+
+TEST(CacheSlotTrackerTest, PassthroughFileOverheadParticipatesInAdmission) {
+    ResourceUsage limit{110, 200};
+    auto dlist = std::make_shared<DList>(true, limit, limit, limit, EvictionConfig{10, true, 600});
+    dlist->SetLoadingOverheadTracker(std::make_shared<LoadingOverheadTracker>());
+
+    auto translator = std::make_unique<MockTranslator>(std::vector<std::pair<cid_t, int64_t>>{{0, 10}},
+                                                       std::unordered_map<cl_uid_t, cid_t>{{0, 0}},
+                                                       "test_dimension_admission", StorageType::MEMORY);
+    translator->SetLoadingOverhead({200, 200});
+    translator->SetLoadingOverheadConfig(
+        LoadingOverheadConfig{LoadingOverheadDimensionConfig{100, "load_transient"}, std::nullopt});
+
+    auto cache_slot = std::make_shared<CacheSlot<TestCell>>(std::move(translator), dlist.get(), true, true, false,
+                                                            std::chrono::milliseconds(0), std::chrono::milliseconds(0));
+    auto op_ctx = std::make_unique<milvus::OpContext>();
+
+    EXPECT_NO_THROW(cache_slot->PinCellsDirect(op_ctx.get(), {0}));
+}
+
+TEST(CacheSlotTrackerTest, InsufficientDiskRejectsPassthroughFileOverhead) {
+    ResourceUsage limit{1000, 199};
+    auto dlist = std::make_shared<DList>(true, limit, limit, limit, EvictionConfig{10, true, 600});
+    dlist->SetLoadingOverheadTracker(std::make_shared<LoadingOverheadTracker>());
+
+    auto translator = std::make_unique<MockTranslator>(std::vector<std::pair<cid_t, int64_t>>{{0, 10}},
+                                                       std::unordered_map<cl_uid_t, cid_t>{{0, 0}},
+                                                       "test_dimension_disk_reject", StorageType::MEMORY);
+    translator->SetLoadingOverhead({200, 200});
+    translator->SetLoadingOverheadConfig(
+        LoadingOverheadConfig{LoadingOverheadDimensionConfig{100, "load_transient"}, std::nullopt});
+    auto* translator_ptr = translator.get();
+
+    auto cache_slot = std::make_shared<CacheSlot<TestCell>>(std::move(translator), dlist.get(), true, true, false,
+                                                            std::chrono::milliseconds(0), std::chrono::milliseconds(0));
+    auto op_ctx = std::make_unique<milvus::OpContext>();
+
+    EXPECT_ANY_THROW(cache_slot->PinCellsDirect(op_ctx.get(), {0}));
+    EXPECT_EQ(translator_ptr->GetCellsCallCount(), 0);
 }
 
 // Test that tracker state is properly cleaned up when load throws an exception.

--- a/test/test_cachinglayer/test_cache_slot.cpp
+++ b/test/test_cachinglayer/test_cache_slot.cpp
@@ -185,10 +185,6 @@ class MockTranslator : public Translator<TestCell> {
         extra_cids_ = extra_cids;
     }
     void
-    SetLoadingOverheadBytes(int64_t bytes) {
-        loading_overhead_ = {bytes, 0};
-    }
-    void
     SetLoadingOverhead(ResourceUsage loading_overhead) {
         loading_overhead_ = loading_overhead;
     }
@@ -2167,7 +2163,7 @@ TEST(CacheSlotTrackerTest, LoadingOverheadTrackerIntegration) {
     auto translator = std::make_unique<MockTranslator>(
         std::vector<std::pair<cid_t, int64_t>>{{0, cell_loaded_size}, {1, cell_loaded_size}},
         std::unordered_map<cl_uid_t, cid_t>{{0, 0}, {1, 1}}, "test_tracker_integration", StorageType::MEMORY);
-    translator->SetLoadingOverheadBytes(cell_loading_overhead);
+    translator->SetLoadingOverhead({cell_loading_overhead, 0});
     translator->SetLoadingOverheadConfig("test_group", {500, 0});
     auto* translator_ptr = translator.get();
 
@@ -2244,7 +2240,7 @@ TEST(CacheSlotTrackerTest, LoadingOverheadTrackerCleanupOnException) {
     auto translator = std::make_unique<MockTranslator>(std::vector<std::pair<cid_t, int64_t>>{{0, cell_loaded_size}},
                                                        std::unordered_map<cl_uid_t, cid_t>{{0, 0}},
                                                        "test_tracker_exception", StorageType::MEMORY);
-    translator->SetLoadingOverheadBytes(cell_loading_overhead);
+    translator->SetLoadingOverhead({cell_loading_overhead, 0});
     translator->SetLoadingOverheadConfig("test_group", {500, 0});
     translator->SetShouldThrow(true);
 
@@ -2288,7 +2284,7 @@ TEST(CacheSlotTrackerTest, BonusCellsRetryWithTracker) {
     auto translator = std::make_unique<MockTranslator>(
         std::vector<std::pair<cid_t, int64_t>>{{0, cell_loaded_size}, {1, cell_loaded_size}, {2, cell_loaded_size}},
         std::unordered_map<cl_uid_t, cid_t>{{0, 0}, {1, 1}, {2, 2}}, "test_bonus_retry", StorageType::MEMORY);
-    translator->SetLoadingOverheadBytes(cell_loading_overhead);
+    translator->SetLoadingOverhead({cell_loading_overhead, 0});
     translator->SetLoadingOverheadConfig("test_bonus_retry", {100, 0});
     translator->SetExtraReturnCids({{0, {1, 2}}});
 

--- a/test/test_cachinglayer/test_loading_overhead_tracker.cpp
+++ b/test/test_cachinglayer/test_loading_overhead_tracker.cpp
@@ -306,6 +306,21 @@ TEST_F(LoadingOverheadTrackerTest, GetUpperBound) {
     EXPECT_EQ(ub.file_bytes, 100);
 }
 
+TEST_F(LoadingOverheadTrackerTest, LegacyConfigConstructorConfiguresBothDimensions) {
+    ResourceUsage upper_bound{200, 50};
+    LoadingOverheadConfig config(upper_bound, "legacy_group");
+
+    ASSERT_TRUE(config.memory.has_value());
+    EXPECT_EQ(config.memory->upper_bound, 200);
+    EXPECT_EQ(config.memory->group, "legacy_group");
+    ASSERT_TRUE(config.file.has_value());
+    EXPECT_EQ(config.file->upper_bound, 50);
+    EXPECT_EQ(config.file->group, "legacy_group");
+
+    auto handle = tracker_.Register(config);
+    EXPECT_EQ(tracker_.GetUpperBound(handle), upper_bound);
+}
+
 TEST_F(LoadingOverheadTrackerTest, DimensionsShareMemoryWhileScalarFilePassesThrough) {
     auto scalar_handle =
         tracker_.Register(LoadingOverheadConfig{LoadingOverheadDimensionConfig{200, "load_transient"}, std::nullopt});

--- a/test/test_cachinglayer/test_loading_overhead_tracker.cpp
+++ b/test/test_cachinglayer/test_loading_overhead_tracker.cpp
@@ -156,10 +156,11 @@ TEST_F(LoadingOverheadTrackerTest, RegisterUpperBoundTakesMax) {
 }
 
 TEST_F(LoadingOverheadTrackerTest, HasFiniteUpperBound) {
-    auto handle = tracker_.Register("vector_index", LoadingOverheadTracker::kUnlimited);
-    EXPECT_FALSE(tracker_.HasFiniteUpperBound(handle));
-    handle = tracker_.Register("vector_index", {200, 0});
-    EXPECT_TRUE(tracker_.HasFiniteUpperBound(handle));
+    auto unlimited_handle = tracker_.Register("vector_index", LoadingOverheadTracker::kUnlimited);
+    EXPECT_FALSE(tracker_.HasFiniteUpperBound(unlimited_handle));
+
+    auto finite_handle = tracker_.Register("finite_vector_index", {200, 0});
+    EXPECT_TRUE(tracker_.HasFiniteUpperBound(finite_handle));
 
     auto scalar_handle = tracker_.Register("scalar_field", LoadingOverheadTracker::kUnlimited);
     EXPECT_FALSE(tracker_.HasFiniteUpperBound(scalar_handle));
@@ -215,16 +216,17 @@ TEST_F(LoadingOverheadTrackerTest, DefaultUnlimitedUBFallback) {
     EXPECT_EQ(r2.memory_bytes, 2000000000);
 }
 
-TEST_F(LoadingOverheadTrackerTest, RegisterUnlimitedThenFiniteUB) {
+TEST_F(LoadingOverheadTrackerTest, RegisterUnlimitedThenFiniteKeepsUnlimited) {
     auto handle = tracker_.Register("vector_index", LoadingOverheadTracker::kUnlimited);
     EXPECT_FALSE(tracker_.HasFiniteUpperBound(handle));
 
     handle = tracker_.Register("vector_index", {200, 0});
-    EXPECT_TRUE(tracker_.HasFiniteUpperBound(handle));
+    EXPECT_FALSE(tracker_.HasFiniteUpperBound(handle));
 
-    // Now capping should apply.
+    // INT64_MAX is an explicit unlimited upper bound. Use a missing dimension
+    // when loading overhead should pass through without joining a capped group.
     auto d1 = tracker_.Reserve(handle, {300, 0});
-    EXPECT_EQ(d1.memory_bytes, 200);
+    EXPECT_EQ(d1.memory_bytes, 300);
 }
 
 TEST_F(LoadingOverheadTrackerTest, UnregisteredTypeAutoCreatesUnlimited) {
@@ -268,42 +270,52 @@ TEST_F(LoadingOverheadTrackerTest, UBChangesMidFlight) {
     EXPECT_EQ(total_reserved, total_released);
 }
 
-TEST_F(LoadingOverheadTrackerTest, UBDecreasesFromUnlimitedMidFlight) {
+TEST_F(LoadingOverheadTrackerTest, UnlimitedUBDoesNotDecreaseMidFlight) {
     auto handle = tracker_.Register("vector_index", LoadingOverheadTracker::kUnlimited);
     auto d1 = tracker_.Reserve(handle, {1000, 0});
     EXPECT_EQ(d1.memory_bytes, 1000);
     auto d2 = tracker_.Reserve(handle, {1000, 0});
     EXPECT_EQ(d2.memory_bytes, 1000);
 
-    // Now register finite UB=200
+    // A later finite registration must not lower an explicit unlimited upper bound.
     handle = tracker_.Register("vector_index", {200, 0});
 
-    // Further reserves should be capped
     auto d3 = tracker_.Reserve(handle, {100, 0});
-    EXPECT_EQ(d3.memory_bytes, 0);
+    EXPECT_EQ(d3.memory_bytes, 100);
 
-    // Release all 3: should release exactly 2000
     auto r1 = tracker_.Release(handle, {1000, 0});
-    EXPECT_EQ(r1.memory_bytes, 1800);
+    EXPECT_EQ(r1.memory_bytes, 1000);
     auto r2 = tracker_.Release(handle, {1000, 0});
-    EXPECT_EQ(r2.memory_bytes, 100);
+    EXPECT_EQ(r2.memory_bytes, 1000);
     auto r3 = tracker_.Release(handle, {100, 0});
     EXPECT_EQ(r3.memory_bytes, 100);
 
     int64_t total_reserved = d1.memory_bytes + d2.memory_bytes + d3.memory_bytes;
     int64_t total_released = r1.memory_bytes + r2.memory_bytes + r3.memory_bytes;
-    EXPECT_EQ(total_reserved, 2000);
-    EXPECT_EQ(total_released, 2000);
+    EXPECT_EQ(total_reserved, 2100);
+    EXPECT_EQ(total_released, 2100);
 }
 
 TEST_F(LoadingOverheadTrackerTest, GetUpperBound) {
-    auto handle = tracker_.Register("vector_index", LoadingOverheadTracker::kUnlimited);
-    EXPECT_EQ(tracker_.GetUpperBound(handle), LoadingOverheadTracker::kUnlimited);
+    auto unlimited_handle = tracker_.Register("vector_index", LoadingOverheadTracker::kUnlimited);
+    EXPECT_EQ(tracker_.GetUpperBound(unlimited_handle), LoadingOverheadTracker::kUnlimited);
 
-    handle = tracker_.Register("vector_index", {200, 100});
-    auto ub = tracker_.GetUpperBound(handle);
+    auto finite_handle = tracker_.Register("finite_vector_index", {200, 100});
+    auto ub = tracker_.GetUpperBound(finite_handle);
     EXPECT_EQ(ub.memory_bytes, 200);
     EXPECT_EQ(ub.file_bytes, 100);
+}
+
+TEST_F(LoadingOverheadTrackerTest, PartialUnlimitedRemainsUnlimitedRegardlessOfRegistrationOrder) {
+    constexpr auto kMax = std::numeric_limits<int64_t>::max();
+
+    auto max_first = tracker_.Register("max_first", {kMax, 0});
+    tracker_.Register("max_first", {200, 0});
+    EXPECT_EQ(tracker_.GetUpperBound(max_first), (ResourceUsage{kMax, 0}));
+
+    auto finite_first = tracker_.Register("finite_first", {200, 0});
+    tracker_.Register("finite_first", {kMax, 0});
+    EXPECT_EQ(tracker_.GetUpperBound(finite_first), (ResourceUsage{kMax, 0}));
 }
 
 TEST_F(LoadingOverheadTrackerTest, LegacyConfigConstructorConfiguresBothDimensions) {

--- a/test/test_cachinglayer/test_loading_overhead_tracker.cpp
+++ b/test/test_cachinglayer/test_loading_overhead_tracker.cpp
@@ -3,6 +3,7 @@
 #include <thread>
 #include <vector>
 
+#include "cachinglayer/LoadingOverhead.h"
 #include "cachinglayer/LoadingOverheadTracker.h"
 #include "cachinglayer/Utils.h"
 
@@ -303,4 +304,50 @@ TEST_F(LoadingOverheadTrackerTest, GetUpperBound) {
     auto ub = tracker_.GetUpperBound(handle);
     EXPECT_EQ(ub.memory_bytes, 200);
     EXPECT_EQ(ub.file_bytes, 100);
+}
+
+TEST_F(LoadingOverheadTrackerTest, DimensionsShareMemoryWhileScalarFilePassesThrough) {
+    auto scalar_handle =
+        tracker_.Register(LoadingOverheadConfig{LoadingOverheadDimensionConfig{200, "load_transient"}, std::nullopt});
+    auto field_handle = tracker_.Register(LoadingOverheadConfig{LoadingOverheadDimensionConfig{200, "load_transient"},
+                                                                LoadingOverheadDimensionConfig{50, "load_transient"}});
+
+    auto scalar_first = tracker_.Reserve(scalar_handle, {150, 100});
+    EXPECT_EQ(scalar_first, (ResourceUsage{150, 100}));
+
+    auto field_first = tracker_.Reserve(field_handle, {100, 40});
+    EXPECT_EQ(field_first, (ResourceUsage{50, 40}));
+
+    auto scalar_second = tracker_.Reserve(scalar_handle, {100, 200});
+    EXPECT_EQ(scalar_second, (ResourceUsage{0, 200}));
+
+    auto field_second = tracker_.Reserve(field_handle, {0, 20});
+    EXPECT_EQ(field_second, (ResourceUsage{0, 10}));
+
+    auto scalar_first_release = tracker_.Release(scalar_handle, {150, 100});
+    EXPECT_EQ(scalar_first_release, (ResourceUsage{0, 100}));
+
+    auto field_first_release = tracker_.Release(field_handle, {100, 40});
+    EXPECT_EQ(field_first_release, (ResourceUsage{100, 30}));
+
+    auto scalar_second_release = tracker_.Release(scalar_handle, {100, 200});
+    EXPECT_EQ(scalar_second_release, (ResourceUsage{100, 200}));
+
+    auto field_second_release = tracker_.Release(field_handle, {0, 20});
+    EXPECT_EQ(field_second_release, (ResourceUsage{0, 20}));
+}
+
+TEST_F(LoadingOverheadTrackerTest, PassthroughRegistrationDoesNotPolluteFiniteFileGroup) {
+    auto field_handle = tracker_.Register(LoadingOverheadConfig{LoadingOverheadDimensionConfig{200, "load_transient"},
+                                                                LoadingOverheadDimensionConfig{50, "load_transient"}});
+    auto scalar_handle =
+        tracker_.Register(LoadingOverheadConfig{LoadingOverheadDimensionConfig{200, "load_transient"}, std::nullopt});
+
+    EXPECT_EQ(tracker_.GetUpperBound(field_handle), (ResourceUsage{200, 50}));
+    EXPECT_EQ(tracker_.GetUpperBound(scalar_handle), (ResourceUsage{200, std::numeric_limits<int64_t>::max()}));
+
+    auto scalar = tracker_.Reserve(scalar_handle, {0, 100});
+    auto field = tracker_.Reserve(field_handle, {0, 100});
+    EXPECT_EQ(scalar.file_bytes, 100);
+    EXPECT_EQ(field.file_bytes, 50);
 }


### PR DESCRIPTION
- track memory and file loading overhead with independent group caps
- pass unconfigured dimensions through to DList admission
- preserve the legacy shared-group constructor by mapping it to both dimensions, so existing Cardinal callers remain source-compatible
- cover shared memory caps, temporary disk rejection, and legacy config registration

Refs: https://github.com/milvus-io/milvus/pull/51403