### PR TITLE
enhance: add type-erased pinned segment state slot to OpContext

### DIFF
--- a/include/common/OpContext.h
+++ b/include/common/OpContext.h
@@ -50,6 +50,16 @@ struct OpContext {
     // independent of segcore's FieldId type.
     std::vector<int64_t> coload_fields;
 
+    // Pinned read snapshot for the segment this operation runs on. Set once by
+    // the segment at operation entry (see milvus segcore: sealed-segment
+    // per-operation snapshot pinning); readers cast it back via
+    // std::static_pointer_cast. Type-erased so common/ stays independent of
+    // segcore types. `pinned_state_owner` identifies the segment that set the
+    // pin: a reader must ignore the pin unless the owner matches itself, which
+    // guards against an OpContext being reused across segments.
+    std::shared_ptr<const void> pinned_segment_state;
+    const void* pinned_state_owner = nullptr;
+
     std::optional<tracer::OwnedTraceContext> trace_context;
 
     void


### PR DESCRIPTION
Adds two fields to `OpContext` as the carrier for sealed-segment per-operation snapshot pinning in milvus segcore: at operation entry the segment pins its published state into the operation's context, so every accessor within that operation reads one immutable snapshot — a concurrent Reopen republishing state mid-operation must not be observed mid-scan. The slot is type-erased (`std::shared_ptr<const void>`) so milvus-common stays independent of segcore types, and `pinned_state_owner` lets a reader ignore a pin set by a different segment when an OpContext is reused. The milvus-side usage follows in a milvus PR (design doc: milvus repo `docs/design-docs/design_docs/20260717-sealed-segment-op-snapshot-pinning.md`).

This is a pure additive, ABI-compatible field addition: OpContext remains non-copyable/non-movable with no virtual methods, and the new fields default to empty/nullptr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)