### PR TITLE
enhance: add coload_fields hint to OpContext for coalesced column reads

### DIFF
--- a/include/common/OpContext.h
+++ b/include/common/OpContext.h
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <vector>
 
 #include "common/Tracer.h"
 
@@ -40,6 +41,14 @@ struct OpContext {
     // Runtime load priority that overrides the translator's cached priority.
     // Maps to proto::common::LoadPriority (milvus-proto): HIGH = 0, LOW = 1.
     std::optional<int32_t> runtime_load_priority;
+
+    // Coalesced-read hint: the field ids (FieldId::get() values) this operation
+    // will read. Set once by the caller at operation entry. A per-field cache
+    // reader may use it to co-load the sibling hinted fields of the same
+    // column group in one IO instead of a separate read per field. Empty = no
+    // hint (each field loaded independently). Raw int64 keeps common/
+    // independent of segcore's FieldId type.
+    std::vector<int64_t> coload_fields;
 
     std::optional<tracer::OwnedTraceContext> trace_context;
 


### PR DESCRIPTION
## What
Adds an optional `coload_fields` hint to `OpContext` — a vector of raw field-id values (`FieldId::get()`) that the current operation will read.

## Why
Milvus segcore's storage-v3 column-group cache is moving to per-(field, chunk) cache cells (each cell holds one field). When a query reads several columns of the same column group, a per-field reader uses this hint to co-load the sibling hinted fields of the same group in a single IO instead of one read per field.

- Empty `coload_fields` = no hint; each field is loaded independently (current behaviour).
- Raw `int64` (not `FieldId`) keeps `common/` independent of segcore types, consistent with the existing type-erased `pinned_segment_state` slot.

Header-only, additive, backward-compatible.

## Consumer
The upcoming milvus PR (per-field cache cells + coalesced reads) bumps the milvus-common pin to include this field and populates it from `plan->access_entries_`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)