### PR TITLE
fix: refresh cache loading overhead bounds

### DIFF
--- a/include/cachinglayer/CacheSlot.h
+++ b/include/cachinglayer/CacheSlot.h
@@ -82,8 +82,8 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
         monitor::cache_cell_count(cell_data_type_, storage_type_).Increment(translator_->num_cells());
         // Register after all potentially-throwing operations, so that if the constructor
         // fails, we don't leak a ref_count (destructor won't run for incomplete objects).
-        if (auto& lo = translator_->meta()->loading_overhead) {
-            overhead_handle_ = dlist_->RegisterLoadingOverhead(*lo);
+        if (auto loading_overhead = translator_->loading_overhead_config()) {
+            overhead_handle_ = dlist_->RegisterLoadingOverhead(*loading_overhead);
         }
     }
 
@@ -441,6 +441,9 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
         //   pass through unchanged. The tracker returns the combined incremental DList delta.
         std::vector<cid_t> loading_cids;
         try {
+            if (auto loading_overhead = translator_->loading_overhead_config()) {
+                dlist_->RefreshLoadingOverheadUpperBound(overhead_handle_, *loading_overhead);
+            }
             auto start = std::chrono::steady_clock::now();
 
             loading_cids = std::vector<cid_t>(cids.begin(), cids.end());

--- a/include/cachinglayer/LoadingOverheadTracker.h
+++ b/include/cachinglayer/LoadingOverheadTracker.h
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <map>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -23,6 +24,10 @@
 
 namespace milvus::cachinglayer {
 
+namespace internal {
+class DList;
+}
+
 // Manages per-dimension, per-group loading overhead reservation with an upper bound (UB).
 //
 // Memory and file groups are independent even when they use the same string key.
@@ -31,7 +36,9 @@ namespace milvus::cachinglayer {
 // The total loading overhead reserved from DList for each configured dimension is capped:
 //   DList dimension reservation = min(sum_of_overhead, dimension_UB)
 // An unconfigured dimension passes through unchanged. INT64_MAX is an explicit
-// unlimited upper bound; re-registering a group can only increase its upper bound.
+// unlimited upper bound. A group's effective upper bound is the maximum reported
+// by its live registrations, so refreshing or unregistering one registration can
+// safely recompute the group bound without affecting other contributors.
 //
 // Each Reserve/Release call returns the incremental delta to apply to DList.
 // The tracker directly tracks `overhead_reserved` (actual amount of overhead currently
@@ -51,12 +58,14 @@ class LoadingOverheadTracker {
         std::lock_guard<std::mutex> lock(mtx_);
         RegistrationState registration;
         if (config.memory.has_value()) {
-            registration.memory_group_handle =
+            registration.memory.group_handle =
                 registerDimensionGroup(memory_name_to_group_handle_, config.memory.value(), "memory");
+            registration.memory.upper_bound = config.memory->upper_bound;
         }
         if (config.file.has_value()) {
-            registration.file_group_handle =
+            registration.file.group_handle =
                 registerDimensionGroup(file_name_to_group_handle_, config.file.value(), "file");
+            registration.file.upper_bound = config.file->upper_bound;
         }
 
         auto handle = next_registration_handle_++;
@@ -80,11 +89,11 @@ class LoadingOverheadTracker {
             return loading_overhead;
         }
         auto delta = loading_overhead;
-        if (it->second.memory_group_handle != kInvalidHandle) {
-            delta.memory_bytes = reserveDimension(it->second.memory_group_handle, loading_overhead.memory_bytes);
+        if (it->second.memory.group_handle != kInvalidHandle) {
+            delta.memory_bytes = reserveDimension(it->second.memory.group_handle, loading_overhead.memory_bytes);
         }
-        if (it->second.file_group_handle != kInvalidHandle) {
-            delta.file_bytes = reserveDimension(it->second.file_group_handle, loading_overhead.file_bytes);
+        if (it->second.file.group_handle != kInvalidHandle) {
+            delta.file_bytes = reserveDimension(it->second.file.group_handle, loading_overhead.file_bytes);
         }
         return delta;
     }
@@ -99,11 +108,11 @@ class LoadingOverheadTracker {
             return loading_overhead;
         }
         auto delta = loading_overhead;
-        if (it->second.memory_group_handle != kInvalidHandle) {
-            delta.memory_bytes = releaseDimension(it->second.memory_group_handle, loading_overhead.memory_bytes);
+        if (it->second.memory.group_handle != kInvalidHandle) {
+            delta.memory_bytes = releaseDimension(it->second.memory.group_handle, loading_overhead.memory_bytes);
         }
-        if (it->second.file_group_handle != kInvalidHandle) {
-            delta.file_bytes = releaseDimension(it->second.file_group_handle, loading_overhead.file_bytes);
+        if (it->second.file.group_handle != kInvalidHandle) {
+            delta.file_bytes = releaseDimension(it->second.file.group_handle, loading_overhead.file_bytes);
         }
         return delta;
     }
@@ -120,6 +129,30 @@ class LoadingOverheadTracker {
         return getUpperBoundLocked(handle);
     }
 
+    // Refresh a registration without changing its ref count. Dimensions and
+    // group names are fixed at registration; only each registration's upper-bound
+    // contribution is updated. The group's effective bound remains the maximum
+    // contribution from all live registrations.
+    void
+    RefreshUpperBound(uint64_t handle, const LoadingOverheadConfig& config) {
+        if (handle == kInvalidHandle) {
+            return;
+        }
+        std::lock_guard<std::mutex> lock(mtx_);
+        auto it = registration_state_.find(handle);
+        if (it == registration_state_.end()) {
+            return;
+        }
+        if (config.memory.has_value()) {
+            refreshDimensionUpperBound(it->second.memory.group_handle, it->second.memory.upper_bound,
+                                       config.memory.value(), "memory");
+        }
+        if (config.file.has_value()) {
+            refreshDimensionUpperBound(it->second.file.group_handle, it->second.file.upper_bound, config.file.value(),
+                                       "file");
+        }
+    }
+
     // Decrement ref count for a group. When ref count reaches 0, the group is
     // unconditionally removed. Safe to call from CacheSlot destructor.
     void
@@ -132,24 +165,55 @@ class LoadingOverheadTracker {
         if (it == registration_state_.end()) {
             return;
         }
-        unregisterDimensionGroup(memory_name_to_group_handle_, it->second.memory_group_handle, "memory");
-        unregisterDimensionGroup(file_name_to_group_handle_, it->second.file_group_handle, "file");
+        unregisterDimensionGroup(memory_name_to_group_handle_, it->second.memory.group_handle,
+                                 it->second.memory.upper_bound, "memory");
+        unregisterDimensionGroup(file_name_to_group_handle_, it->second.file.group_handle, it->second.file.upper_bound,
+                                 "file");
         registration_state_.erase(it);
     }
 
  private:
+    friend class internal::DList;
+
     struct DimensionGroupState {
         int64_t upper_bound{0};
         int64_t sum_of_overhead{0};
         int64_t overhead_reserved{0};
         uint64_t ref_count{0};
         std::string group_name;
+        std::map<int64_t, uint64_t> upper_bound_ref_counts;
+    };
+
+    struct DimensionRegistrationState {
+        uint64_t group_handle{kInvalidHandle};
+        int64_t upper_bound{0};
     };
 
     struct RegistrationState {
-        uint64_t memory_group_handle{kInvalidHandle};
-        uint64_t file_group_handle{kInvalidHandle};
+        DimensionRegistrationState memory;
+        DimensionRegistrationState file;
     };
+
+    static void
+    addUpperBoundContribution(DimensionGroupState& state, int64_t upper_bound) {
+        state.upper_bound_ref_counts[upper_bound]++;
+        state.upper_bound = state.upper_bound_ref_counts.rbegin()->first;
+    }
+
+    static bool
+    removeUpperBoundContribution(DimensionGroupState& state, int64_t upper_bound) {
+        auto it = state.upper_bound_ref_counts.find(upper_bound);
+        if (it == state.upper_bound_ref_counts.end()) {
+            LOG_ERROR("[MCL] LoadingOverheadTracker group '{}' is missing UB contribution {}", state.group_name,
+                      upper_bound);
+            return false;
+        }
+        if (--it->second == 0) {
+            state.upper_bound_ref_counts.erase(it);
+        }
+        state.upper_bound = state.upper_bound_ref_counts.empty() ? 0 : state.upper_bound_ref_counts.rbegin()->first;
+        return true;
+    }
 
     uint64_t
     registerDimensionGroup(std::unordered_map<std::string, uint64_t>& name_to_handle,
@@ -157,13 +221,14 @@ class LoadingOverheadTracker {
         auto it = name_to_handle.find(config.group);
         if (it != name_to_handle.end()) {
             auto& state = dimension_group_state_[it->second];
+            auto previous_upper_bound = state.upper_bound;
+            addUpperBoundContribution(state, config.upper_bound);
             state.ref_count++;
-            if (state.upper_bound < config.upper_bound) {
-                LOG_WARN(
-                    "[MCL] LoadingOverheadTracker {} UB mismatch for group '{}' (handle {}): existing={}, new={}. "
-                    "Taking max.",
-                    dimension, config.group, it->second, state.upper_bound, config.upper_bound);
-                state.upper_bound = config.upper_bound;
+            if (previous_upper_bound != config.upper_bound) {
+                LOG_DEBUG(
+                    "[MCL] LoadingOverheadTracker added {} UB contribution for group '{}' (handle {}): "
+                    "existing={}, new={}, effective={}",
+                    dimension, config.group, it->second, previous_upper_bound, config.upper_bound, state.upper_bound);
             } else {
                 LOG_DEBUG("[MCL] LoadingOverheadTracker re-registered {} group '{}' (handle {}, refs={}), UB unchanged",
                           dimension, config.group, it->second, state.ref_count);
@@ -173,7 +238,10 @@ class LoadingOverheadTracker {
 
         auto handle = next_group_handle_++;
         name_to_handle[config.group] = handle;
-        dimension_group_state_[handle] = DimensionGroupState{config.upper_bound, 0, 0, 1, config.group};
+        auto& state = dimension_group_state_[handle];
+        state.ref_count = 1;
+        state.group_name = config.group;
+        addUpperBoundContribution(state, config.upper_bound);
         LOG_INFO("[MCL] LoadingOverheadTracker registered {} group '{}' (handle {}, refs=1): UB={}", dimension,
                  config.group, handle, config.upper_bound);
         return handle;
@@ -187,6 +255,75 @@ class LoadingOverheadTracker {
         auto delta = std::max(target - state.overhead_reserved, int64_t{0});
         state.overhead_reserved += delta;
         return delta;
+    }
+
+    void
+    refreshDimensionUpperBound(uint64_t group_handle, int64_t& registered_upper_bound,
+                               const LoadingOverheadDimensionConfig& config, const char* dimension) {
+        if (group_handle == kInvalidHandle) {
+            return;
+        }
+        auto it = dimension_group_state_.find(group_handle);
+        if (it == dimension_group_state_.end()) {
+            return;
+        }
+        auto& state = it->second;
+        if (state.group_name != config.group) {
+            LOG_WARN("[MCL] LoadingOverheadTracker cannot refresh {} group '{}' through registration for group '{}'",
+                     dimension, config.group, state.group_name);
+            return;
+        }
+        if (registered_upper_bound == config.upper_bound) {
+            return;
+        }
+        auto previous_group_upper_bound = state.upper_bound;
+        addUpperBoundContribution(state, config.upper_bound);
+        if (!removeUpperBoundContribution(state, registered_upper_bound)) {
+            removeUpperBoundContribution(state, config.upper_bound);
+            return;
+        }
+        auto previous_registration_upper_bound = registered_upper_bound;
+        registered_upper_bound = config.upper_bound;
+        LOG_INFO(
+            "[MCL] LoadingOverheadTracker refreshed {} group '{}' (handle {}): registration UB {} -> {}, "
+            "group UB {} -> {}",
+            dimension, config.group, group_handle, previous_registration_upper_bound, config.upper_bound,
+            previous_group_upper_bound, state.upper_bound);
+    }
+
+    // Undo a failed Reserve using the exact delta returned by that attempt.
+    // This differs from Release when an upper-bound refresh makes Reserve catch
+    // up previously capped overhead in addition to the current request.
+    void
+    rollbackReserve(uint64_t handle, const ResourceUsage& loading_overhead, const ResourceUsage& reserved_delta) {
+        std::lock_guard<std::mutex> lock(mtx_);
+        auto it = registration_state_.find(handle);
+        if (it == registration_state_.end()) {
+            return;
+        }
+        if (it->second.memory.group_handle != kInvalidHandle) {
+            rollbackReserveDimension(it->second.memory.group_handle, loading_overhead.memory_bytes,
+                                     reserved_delta.memory_bytes);
+        }
+        if (it->second.file.group_handle != kInvalidHandle) {
+            rollbackReserveDimension(it->second.file.group_handle, loading_overhead.file_bytes,
+                                     reserved_delta.file_bytes);
+        }
+    }
+
+    void
+    rollbackReserveDimension(uint64_t group_handle, int64_t overhead, int64_t reserved_delta) {
+        auto& state = dimension_group_state_.at(group_handle);
+        state.sum_of_overhead -= overhead;
+        state.overhead_reserved -= reserved_delta;
+        if (state.sum_of_overhead < 0 || state.overhead_reserved < 0) {
+            LOG_ERROR(
+                "[MCL] LoadingOverheadTracker rollback group handle {} produced negative state: "
+                "sum_of_overhead={}, overhead_reserved={}",
+                group_handle, state.sum_of_overhead, state.overhead_reserved);
+            state.sum_of_overhead = std::max(state.sum_of_overhead, int64_t{0});
+            state.overhead_reserved = std::max(state.overhead_reserved, int64_t{0});
+        }
     }
 
     int64_t
@@ -210,18 +347,18 @@ class LoadingOverheadTracker {
             return kUnlimited;
         }
         ResourceUsage result = kUnlimited;
-        if (it->second.memory_group_handle != kInvalidHandle) {
-            result.memory_bytes = dimension_group_state_.at(it->second.memory_group_handle).upper_bound;
+        if (it->second.memory.group_handle != kInvalidHandle) {
+            result.memory_bytes = dimension_group_state_.at(it->second.memory.group_handle).upper_bound;
         }
-        if (it->second.file_group_handle != kInvalidHandle) {
-            result.file_bytes = dimension_group_state_.at(it->second.file_group_handle).upper_bound;
+        if (it->second.file.group_handle != kInvalidHandle) {
+            result.file_bytes = dimension_group_state_.at(it->second.file.group_handle).upper_bound;
         }
         return result;
     }
 
     void
     unregisterDimensionGroup(std::unordered_map<std::string, uint64_t>& name_to_handle, uint64_t group_handle,
-                             const char* dimension) {
+                             int64_t registered_upper_bound, const char* dimension) {
         if (group_handle == kInvalidHandle) {
             return;
         }
@@ -230,6 +367,7 @@ class LoadingOverheadTracker {
             return;
         }
         auto& state = it->second;
+        removeUpperBoundContribution(state, registered_upper_bound);
         if (state.ref_count > 0) {
             state.ref_count--;
         }

--- a/include/cachinglayer/Translator.h
+++ b/include/cachinglayer/Translator.h
@@ -91,6 +91,17 @@ class Translator {
     virtual Meta*
     meta() = 0;
 
+    // Return the current loading-overhead configuration. Translators whose
+    // upper bound depends on refreshable runtime settings can override this;
+    // CacheSlot re-reads it before every load reservation.
+    // Configured dimensions and group names must remain stable for the lifetime
+    // of a CacheSlot. Use INT64_MAX at construction for a dimension that may
+    // transition from uncapped to capped later.
+    virtual std::optional<LoadingOverheadConfig>
+    loading_overhead_config() {
+        return meta()->loading_overhead;
+    }
+
     // Translator may choose to fetch more than requested cells. The default behavior is to not include extra cells.
     virtual std::vector<cid_t>
     bonus_cells_to_be_loaded(const std::vector<cid_t>& cids) const {

--- a/include/cachinglayer/lrucache/DList.h
+++ b/include/cachinglayer/lrucache/DList.h
@@ -86,8 +86,6 @@ class DList : public std::enable_shared_from_this<DList> {
     void
     RefreshLoadingOverheadUpperBound(uint64_t overhead_handle, const LoadingOverheadConfig& config) {
         if (loading_overhead_tracker_) {
-            // Keep refresh ordered with tracker reserve/release and their DList accounting.
-            std::lock_guard<std::mutex> lock(list_mtx_);
             loading_overhead_tracker_->RefreshUpperBound(overhead_handle, config);
         }
     }

--- a/include/cachinglayer/lrucache/DList.h
+++ b/include/cachinglayer/lrucache/DList.h
@@ -83,6 +83,15 @@ class DList : public std::enable_shared_from_this<DList> {
         return LoadingOverheadTracker::kInvalidHandle;
     }
 
+    void
+    RefreshLoadingOverheadUpperBound(uint64_t overhead_handle, const LoadingOverheadConfig& config) {
+        if (loading_overhead_tracker_) {
+            // Keep refresh ordered with tracker reserve/release and their DList accounting.
+            std::lock_guard<std::mutex> lock(list_mtx_);
+            loading_overhead_tracker_->RefreshUpperBound(overhead_handle, config);
+        }
+    }
+
     uint64_t
     RegisterLoadingOverhead(const std::string& group, const ResourceUsage& upper_bound) {
         if (loading_overhead_tracker_) {

--- a/src/cachinglayer/lrucache/DList.cpp
+++ b/src/cachinglayer/lrucache/DList.cpp
@@ -235,9 +235,9 @@ DList::reserveResourceInternalWithTracker(const ResourceUsage& loaded, const Res
     }
     auto actual_size = (loaded + delta) * eviction_config_.loading_resource_factor;
 
-    auto rollback = [overhead_handle, overhead, tracker]() {
+    auto rollback = [overhead_handle, overhead, delta, tracker]() {
         if (overhead_handle != LoadingOverheadTracker::kInvalidHandle && tracker != nullptr) {
-            tracker->Release(overhead_handle, overhead);
+            tracker->rollbackReserve(overhead_handle, overhead, delta);
         }
     };
 
@@ -850,7 +850,8 @@ DList::handleWaitingRequests() {
                     request->use_resource_promise ? actual * eviction_config_.loading_resource_factor : actual;
                 total_loading_size_ -= rollback;
                 if (request->overhead_handle != LoadingOverheadTracker::kInvalidHandle && loading_overhead_tracker_) {
-                    loading_overhead_tracker_->Release(request->overhead_handle, request->overhead);
+                    loading_overhead_tracker_->rollbackReserve(request->overhead_handle, request->overhead,
+                                                               actual - request->loaded);
                 }
             }
             requests_to_destroy.push_back(std::move(request));

--- a/test/test_cachinglayer/cachinglayer_test_utils.h
+++ b/test/test_cachinglayer/cachinglayer_test_utils.h
@@ -13,6 +13,7 @@
 
 #include <gtest/gtest.h>
 
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -27,6 +28,11 @@ using namespace cachinglayer;
 namespace cachinglayer::internal {
 class DListTestFriend {
  public:
+    static std::unique_lock<std::mutex>
+    lock_list(DList& dlist) {
+        return std::unique_lock<std::mutex>(dlist.list_mtx_);
+    }
+
     static ResourceUsage
     get_using_memory(const DList& dlist) {
         return dlist.total_loaded_size_.load() + dlist.total_loading_size_.load();

--- a/test/test_cachinglayer/test_cache_slot.cpp
+++ b/test/test_cachinglayer/test_cache_slot.cpp
@@ -120,6 +120,11 @@ class MockTranslator : public Translator<TestCell> {
         return &meta_;
     }
 
+    std::optional<LoadingOverheadConfig>
+    loading_overhead_config() override {
+        return meta_.loading_overhead;
+    }
+
     std::vector<cid_t>
     bonus_cells_to_be_loaded(const std::vector<cid_t>& cids) const override {
         std::unordered_set<cid_t> total_bonus_cids_set;
@@ -2184,6 +2189,32 @@ TEST(CacheSlotTrackerTest, LoadingOverheadTrackerIntegration) {
     EXPECT_EQ(accessor2->get_cell_of(1)->data, 10);
 
     EXPECT_EQ(translator_ptr->GetCellsCallCount(), 2);
+}
+
+TEST(CacheSlotTrackerTest, RefreshesLoadingOverheadBeforeEachLoad) {
+    ResourceUsage limit{250, 0};
+    auto dlist = std::make_shared<DList>(true, limit, limit, limit, EvictionConfig{10, true, 600});
+    dlist->SetLoadingOverheadTracker(std::make_shared<LoadingOverheadTracker>());
+
+    auto translator = std::make_unique<MockTranslator>(std::vector<std::pair<cid_t, int64_t>>{{0, 10}, {1, 10}},
+                                                       std::unordered_map<cl_uid_t, cid_t>{{0, 0}, {1, 1}},
+                                                       "test_overhead_refresh", StorageType::MEMORY);
+    translator->SetLoadingOverhead({300, 0});
+    translator->SetLoadingOverheadConfig("load_transient", {100, 0});
+    auto* translator_ptr = translator.get();
+
+    auto cache_slot = std::make_shared<CacheSlot<TestCell>>(std::move(translator), dlist.get(), true, true, false,
+                                                            std::chrono::milliseconds(0), std::chrono::milliseconds(0));
+    auto op_ctx = std::make_unique<milvus::OpContext>();
+
+    auto first = cache_slot->PinCellsDirect(op_ctx.get(), {0});
+    ASSERT_NE(first, nullptr);
+    ASSERT_EQ(translator_ptr->GetCellsCallCount(), 1);
+
+    translator_ptr->SetLoadingOverheadConfig("load_transient", {300, 0});
+
+    EXPECT_ANY_THROW(cache_slot->PinCellsDirect(op_ctx.get(), {1}));
+    EXPECT_EQ(translator_ptr->GetCellsCallCount(), 1);
 }
 
 TEST(CacheSlotTrackerTest, PassthroughFileOverheadParticipatesInAdmission) {

--- a/test/test_cachinglayer/test_dlist.cpp
+++ b/test/test_cachinglayer/test_dlist.cpp
@@ -2,6 +2,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <future>
 #include <map>
 #include <memory>
 #include <thread>
@@ -158,6 +159,28 @@ TEST_F(DListTest, FailedReserveAfterOverheadRefreshRollsBackExactTrackerDelta) {
     auto released = dlist->ReleaseLoadingResource({}, {200, 0}, handle);
     EXPECT_EQ(released, (ResourceUsage{100, 0}));
     EXPECT_EQ(get_loading_memory(), ResourceUsage{});
+}
+
+TEST_F(DListTest, RefreshLoadingOverheadDoesNotWaitForListLock) {
+    dlist->SetLoadingOverheadTracker(std::make_shared<LoadingOverheadTracker>());
+    auto handle = dlist->RegisterLoadingOverhead("load_transient", {100, 0});
+    auto config = LoadingOverheadConfig{LoadingOverheadDimensionConfig{200, "load_transient"},
+                                        LoadingOverheadDimensionConfig{0, "load_transient"}};
+
+    auto list_lock = DLF::lock_list(*dlist);
+    std::promise<void> started;
+    auto started_future = started.get_future();
+    auto refresh_future = std::async(std::launch::async, [&]() {
+        started.set_value();
+        dlist->RefreshLoadingOverheadUpperBound(handle, config);
+    });
+
+    started_future.wait();
+    auto status = refresh_future.wait_for(std::chrono::milliseconds(200));
+    list_lock.unlock();
+    refresh_future.get();
+
+    EXPECT_EQ(status, std::future_status::ready);
 }
 
 TEST_F(DListTest, UpdateMaxLimitIncrease) {

--- a/test/test_cachinglayer/test_dlist.cpp
+++ b/test/test_cachinglayer/test_dlist.cpp
@@ -15,6 +15,9 @@
 
 using milvus::cachinglayer::cid_t;
 using milvus::cachinglayer::EvictionConfig;
+using milvus::cachinglayer::LoadingOverheadConfig;
+using milvus::cachinglayer::LoadingOverheadDimensionConfig;
+using milvus::cachinglayer::LoadingOverheadTracker;
 using milvus::cachinglayer::ResourceUsage;
 using milvus::cachinglayer::internal::DList;
 using milvus::cachinglayer::internal::DListTestFriend;
@@ -132,6 +135,29 @@ TEST_F(DListTest, Initialization) {
     EXPECT_EQ(get_loading_memory(), ResourceUsage{});
     EXPECT_EQ(DLF::get_head(*dlist), nullptr);
     EXPECT_EQ(DLF::get_tail(*dlist), nullptr);
+}
+
+TEST_F(DListTest, FailedReserveAfterOverheadRefreshRollsBackExactTrackerDelta) {
+    dlist->SetLoadingOverheadTracker(std::make_shared<LoadingOverheadTracker>());
+    auto handle = dlist->RegisterLoadingOverhead("load_transient", {100, 0});
+
+    auto first =
+        std::move(dlist->ReserveLoadingResourceWithTimeout({}, {200, 0}, handle, std::chrono::milliseconds(0))).get();
+    ASSERT_EQ(first, (ResourceUsage{100, 0}));
+    ASSERT_EQ(get_loading_memory(), (ResourceUsage{100, 0}));
+
+    dlist->RefreshLoadingOverheadUpperBound(handle,
+                                            LoadingOverheadConfig{LoadingOverheadDimensionConfig{300, "load_transient"},
+                                                                  LoadingOverheadDimensionConfig{0, "load_transient"}});
+
+    auto failed =
+        std::move(dlist->ReserveLoadingResourceWithTimeout({}, {150, 0}, handle, std::chrono::milliseconds(0))).get();
+    EXPECT_EQ(failed, ResourceUsage{});
+    EXPECT_EQ(get_loading_memory(), (ResourceUsage{100, 0}));
+
+    auto released = dlist->ReleaseLoadingResource({}, {200, 0}, handle);
+    EXPECT_EQ(released, (ResourceUsage{100, 0}));
+    EXPECT_EQ(get_loading_memory(), ResourceUsage{});
 }
 
 TEST_F(DListTest, UpdateMaxLimitIncrease) {

--- a/test/test_cachinglayer/test_loading_overhead_tracker.cpp
+++ b/test/test_cachinglayer/test_loading_overhead_tracker.cpp
@@ -306,6 +306,57 @@ TEST_F(LoadingOverheadTrackerTest, GetUpperBound) {
     EXPECT_EQ(ub.file_bytes, 100);
 }
 
+TEST_F(LoadingOverheadTrackerTest, RefreshUpperBoundRecomputesSharedGroupWithoutAddingReference) {
+    auto first = tracker_.Register("vector_index", {100, 50});
+    auto second = tracker_.Register("vector_index", {100, 50});
+
+    tracker_.RefreshUpperBound(first, LoadingOverheadConfig{LoadingOverheadDimensionConfig{300, "vector_index"},
+                                                            LoadingOverheadDimensionConfig{25, "vector_index"}});
+
+    EXPECT_EQ(tracker_.GetUpperBound(first), (ResourceUsage{300, 50}));
+    EXPECT_EQ(tracker_.GetUpperBound(second), (ResourceUsage{300, 50}));
+
+    tracker_.RefreshUpperBound(second, LoadingOverheadConfig{LoadingOverheadDimensionConfig{80, "vector_index"},
+                                                             LoadingOverheadDimensionConfig{25, "vector_index"}});
+    EXPECT_EQ(tracker_.GetUpperBound(first), (ResourceUsage{300, 25}));
+
+    tracker_.RefreshUpperBound(first, LoadingOverheadConfig{LoadingOverheadDimensionConfig{60, "vector_index"},
+                                                            LoadingOverheadDimensionConfig{25, "vector_index"}});
+    EXPECT_EQ(tracker_.GetUpperBound(second), (ResourceUsage{80, 25}));
+
+    tracker_.Unregister(first);
+    tracker_.Unregister(second);
+
+    auto replacement = tracker_.Register("vector_index", {80, 40});
+    EXPECT_EQ(tracker_.GetUpperBound(replacement), (ResourceUsage{80, 40}));
+}
+
+TEST_F(LoadingOverheadTrackerTest, RefreshUnlimitedRegistrationToFinite) {
+    auto handle = tracker_.Register("load_transient", LoadingOverheadTracker::kUnlimited);
+
+    tracker_.RefreshUpperBound(handle, LoadingOverheadConfig{LoadingOverheadDimensionConfig{200, "load_transient"},
+                                                             LoadingOverheadDimensionConfig{0, "load_transient"}});
+
+    EXPECT_EQ(tracker_.GetUpperBound(handle), (ResourceUsage{200, 0}));
+}
+
+TEST_F(LoadingOverheadTrackerTest, RefreshDecreaseMidFlightPreservesReservationBalance) {
+    auto handle = tracker_.Register("load_transient", {300, 0});
+
+    auto first = tracker_.Reserve(handle, {200, 0});
+    EXPECT_EQ(first, (ResourceUsage{200, 0}));
+
+    tracker_.RefreshUpperBound(handle, LoadingOverheadConfig{LoadingOverheadDimensionConfig{100, "load_transient"},
+                                                             LoadingOverheadDimensionConfig{0, "load_transient"}});
+
+    auto second = tracker_.Reserve(handle, {50, 0});
+    EXPECT_EQ(second, ResourceUsage{});
+
+    auto second_release = tracker_.Release(handle, {50, 0});
+    auto first_release = tracker_.Release(handle, {200, 0});
+    EXPECT_EQ(second_release + first_release, first);
+}
+
 TEST_F(LoadingOverheadTrackerTest, PartialUnlimitedRemainsUnlimitedRegardlessOfRegistrationOrder) {
     constexpr auto kMax = std::numeric_limits<int64_t>::max();
 


### PR DESCRIPTION
## Summary
- re-read translator loading-overhead config before every CacheSlot load
- track each live registration cap and use the maximum as the shared group bound
- support safe bound increases and decreases with exact failed-reservation rollback
- refresh tracker state without serializing on the DList-wide lock

## Contract
- configured dimensions and group names stay stable for the CacheSlot lifetime
- use INT64_MAX when a dimension starts uncapped but may become capped later

## Test Plan
- `cmake --build . -j8`
- `./build/test/test_cachinglayer/cachinglayer_test` (143 passed)
- `./build/test/all_tests` (112 passed)

Refs: https://github.com/milvus-io/milvus/pull/51403