### PR TITLE
fix: raise FollyCancel on cachinglayer load cancellation

### DIFF
--- a/include/cachinglayer/CacheSlot.h
+++ b/include/cachinglayer/CacheSlot.h
@@ -447,7 +447,7 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
 
             auto run_load_internal = [&]() {
                 if (ctx && ctx->cancellation_token.isCancellationRequested()) {
-                    throw std::runtime_error("Operation cancelled, stop loading cache cells");
+                    ThrowInfo(ErrorCode::FollyCancel, "Operation cancelled, stop loading cache cells");
                 }
                 start = std::chrono::steady_clock::now();
                 auto results = translator_->get_cells(ctx, loading_cids);

--- a/include/cachinglayer/Manager.h
+++ b/include/cachinglayer/Manager.h
@@ -58,7 +58,7 @@ class Manager {
         AssertInfo(dlist_ != nullptr,
                    "dlist_ must be initialized by ConfigureTieredStorage before any CacheSlot is created");
         if (ctx && ctx->cancellation_token.isCancellationRequested()) {
-            throw std::runtime_error("Operation cancelled, stop creating cache slot");
+            ThrowInfo(ErrorCode::FollyCancel, "Operation cancelled, stop creating cache slot");
         }
         auto config = TieredStorageConfig::GetInstance().GetSnapshot();
         auto evictable = translator->meta()->support_eviction && eviction_enabled_;


### PR DESCRIPTION
## What
`CacheSlot::RunLoad` and `Manager`'s cache-slot creation (the cachinglayer load path) threw a plain `std::runtime_error("Operation cancelled, ...")` when the `OpContext` cancellation token was already requested.

## Why
A consumer catching this exception cannot tell a cancellation apart from any other `std::runtime_error`. In Milvus, a query canceled while a **cold cache cell is loading** (`SearchOnSealed` → `PinCells` → `CacheSlot`) therefore surfaces at the exec-driver boundary as a generic `UnexpectedError` instead of `FollyCancel` (2038) — so the cancellation is not treated as one: it is not retried / rerouted and is not counted in the during-execute cancellation metric.

## Change
Throw `ThrowInfo(ErrorCode::FollyCancel, ...)` (a coded `SegcoreError`) at both cancellation checks. `FollyCancel = 2038` is already defined in this repo's `common/EasyAssert.h`, so there is no new dependency, and both files already use the `ThrowInfo`/`AssertInfo` macros. The Milvus exec driver's `catch (SegcoreError&)` then preserves the code end-to-end, so a mid-load cancellation is correctly classified as a cancellation.

Related: milvus-io/milvus#51389 (driver error-code preservation), which relies on cancellations carrying `FollyCancel` from their source.
