### PR TITLE
enhance: carry typed error codes on cachinglayer failure paths and observe untyped cgo exceptions

### DIFF
--- a/include/common/EasyAssert.h
+++ b/include/common/EasyAssert.h
@@ -130,11 +130,29 @@ FailureCStatus(int code, const std::string& msg) {
     return CStatus{code, strdup(msg.data())};
 }
 
+// Observability hook for the cgo boundary: fired whenever FailureCStatus
+// receives an exception that is NOT a SegcoreError (so its typed error code is
+// lost and the failure collapses to UnexpectedError). The consumer (milvus)
+// registers an observer that bumps a metric / logs; a shrinking hit rate means
+// explicit error classification coverage is improving. This header stays free
+// of any metrics dependency -- same observer pattern as the Go-side
+// RegisterUnmappedSegcoreCodeObserver.
+using UntypedCgoExceptionObserver = void (*)(const char* what);
+
+void
+RegisterUntypedCgoExceptionObserver(UntypedCgoExceptionObserver observer);
+
+namespace impl {
+void
+NotifyUntypedCgoException(const char* what);
+}  // namespace impl
+
 inline CStatus
 FailureCStatus(const std::exception* ex) {
     if (auto segcore_err = dynamic_cast<const SegcoreError*>(ex)) {
         return CStatus{static_cast<int>(segcore_err->get_error_code()), strdup(segcore_err->what())};
     }
+    impl::NotifyUntypedCgoException(ex->what());
     return CStatus{static_cast<int>(UnexpectedError), strdup(ex->what())};
 }
 

--- a/include/common/EasyAssert.h
+++ b/include/common/EasyAssert.h
@@ -143,8 +143,11 @@ void
 RegisterUntypedCgoExceptionObserver(UntypedCgoExceptionObserver observer);
 
 namespace impl {
+// Best-effort, noexcept: runs inside FailureCStatus's conversion path, so a
+// throwing observer must never replace the original failure or escape the
+// cgo boundary.
 void
-NotifyUntypedCgoException(const char* what);
+NotifyUntypedCgoException(const char* what) noexcept;
 }  // namespace impl
 
 inline CStatus

--- a/src/cachinglayer/lrucache/ListNode.cpp
+++ b/src/cachinglayer/lrucache/ListNode.cpp
@@ -265,8 +265,7 @@ ListNode::mark_unload(std::function<void()> cb) {
                 // cancellation): a bare runtime_error rethrown from this
                 // promise cannot be recognized at the cgo boundary.
                 promise->setException(folly::exception_wrapper(milvus::SegcoreError(
-                    milvus::ErrorCode::UnexpectedError,
-                    "ListNode destroyed while loading, this should not happen")));
+                    milvus::ErrorCode::UnexpectedError, "ListNode destroyed while loading, this should not happen")));
             }
             break;
         }

--- a/src/cachinglayer/lrucache/ListNode.cpp
+++ b/src/cachinglayer/lrucache/ListNode.cpp
@@ -261,8 +261,12 @@ ListNode::mark_unload(std::function<void()> cb) {
                 // NOTE: it should not happen, but if it does, we should not make the program deadlock.
                 auto promise = std::move(load_promise_);
                 lock.unlock();
-                promise->setException(folly::exception_wrapper(
-                    std::runtime_error("ListNode destroyed while loading, this should not happen")));
+                // Wrap a typed SegcoreError (internal invariant, not a
+                // cancellation): a bare runtime_error rethrown from this
+                // promise cannot be recognized at the cgo boundary.
+                promise->setException(folly::exception_wrapper(milvus::SegcoreError(
+                    milvus::ErrorCode::UnexpectedError,
+                    "ListNode destroyed while loading, this should not happen")));
             }
             break;
         }

--- a/src/common/EasyAssert.cpp
+++ b/src/common/EasyAssert.cpp
@@ -16,11 +16,34 @@
 
 #include "common/EasyAssert.h"
 
+#include <atomic>
 #include <boost/stacktrace.hpp>
 #include <iostream>
 #include <sstream>
 
 #include "fmt/format.h"
+
+namespace milvus {
+
+namespace {
+std::atomic<UntypedCgoExceptionObserver> untyped_cgo_exception_observer{nullptr};
+}  // namespace
+
+void
+RegisterUntypedCgoExceptionObserver(UntypedCgoExceptionObserver observer) {
+    untyped_cgo_exception_observer.store(observer, std::memory_order_release);
+}
+
+namespace impl {
+void
+NotifyUntypedCgoException(const char* what) {
+    if (auto observer = untyped_cgo_exception_observer.load(std::memory_order_acquire)) {
+        observer(what);
+    }
+}
+}  // namespace impl
+
+}  // namespace milvus
 
 namespace milvus::impl {
 

--- a/src/common/EasyAssert.cpp
+++ b/src/common/EasyAssert.cpp
@@ -36,9 +36,17 @@ RegisterUntypedCgoExceptionObserver(UntypedCgoExceptionObserver observer) {
 
 namespace impl {
 void
-NotifyUntypedCgoException(const char* what) {
+NotifyUntypedCgoException(const char* what) noexcept {
     if (auto observer = untyped_cgo_exception_observer.load(std::memory_order_acquire)) {
-        observer(what);
+        try {
+            observer(what);
+        } catch (...) {
+            // The observer is metrics/logging only. It runs inside
+            // FailureCStatus's exception-to-CStatus conversion, so a throwing
+            // observer must never replace the original failure or let an
+            // exception escape the cgo boundary (which would terminate the
+            // process). Swallow and carry on with the conversion.
+        }
     }
 }
 }  // namespace impl


### PR DESCRIPTION
Part of the error-handling hardening tracked in milvus-io/milvus#50903 (see also milvus-io/milvus#50768, which consumes both changes).

## 1. ListNode: loading-in-destructor is an invariant violation, not a cancel

`ListNode::~ListNode` finding a cell still in `LOADING` state is an internal invariant violation — the slot must not be torn down while a load is in flight. It previously threw a bare `std::runtime_error`, which collapses to `UnexpectedError(2001)` at the cgo boundary; now it throws a typed `SegcoreError(UnexpectedError)` explicitly, keeping the intent readable and the throw site consistent with the cancel paths that #111 already typed as `FollyCancel`.

## 2. Observer hook for untyped exceptions at the cgo boundary

`FailureCStatus` recovers the typed code via `dynamic_cast<SegcoreError>`; anything else (a raw `std::exception` from a third-party lib, a sliced rethrow) silently collapses to 2001 and is invisible in production.

This adds `RegisterUntypedCgoExceptionObserver(cb)`: `FailureCStatus` invokes the callback whenever it hits a non-SegcoreError exception. milvus registers a Prometheus counter (`internal_cgo_untyped_exception_total`) plus a rate-limited warn at `SegcoreInit`, so "untyped exception rate should trend to zero" becomes a measurable claim instead of a hope. No behavior change when no observer is registered; a single atomic load on the failure path only.

## Verification

- Full unit suite green on this branch (rebased on current master, incl. #111).
- Consumer side: milvus-io/milvus#50768 unit test `StorageErrorCode.UntypedCgoExceptionObserverFires` exercises the hook end-to-end through `FailureCStatus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
