### PR TITLE
enhance: Add service name differentiation for tracer

### DIFF
--- a/include/common/Tracer.h
+++ b/include/common/Tracer.h
@@ -31,6 +31,7 @@ struct TraceConfig {
     std::string otlpHeaders;
     bool oltpSecure;
 
+    std::string clusterID;
     int nodeID;
 };
 

--- a/src/common/Tracer.cpp
+++ b/src/common/Tracer.cpp
@@ -105,7 +105,8 @@ initTelemetry(const TraceConfig& cfg) {
     }
     if (export_created) {
         auto processor = trace_sdk::BatchSpanProcessorFactory::Create(std::move(exporter), {});
-        resource::ResourceAttributes attributes = {{"service.name", TRACE_SERVICE_SEGCORE}, {"NodeID", cfg.nodeID}};
+        auto service_name = cfg.clusterID + "-" + TRACE_SERVICE_SEGCORE;
+        resource::ResourceAttributes attributes = {{"service.name", service_name}, {"NodeID", cfg.nodeID}};
         auto resource = resource::Resource::Create(attributes);
         auto sampler = std::make_unique<trace_sdk::ParentBasedSampler>(std::make_shared<trace_sdk::AlwaysOnSampler>());
         std::shared_ptr<trace::TracerProvider> provider =


### PR DESCRIPTION
This change improves trace identification when multiple Milvus clusters share the same Jaeger backend. The cluster identifier is passed through TraceConfig and prepended to the Segcore OpenTelemetry service name. As a result, the service name changes from segcore to <cluster-id>-segcore, making it easy to filter and distinguish traces from different clusters in Jaeger while preserving the existing tracing and exporter behavior.
Note: Once this commit is merged, we will submit a corresponding follow-up commit to Milvus to pass the cluster identifier into milvus-common when initializing and resetting the Segcore tracing configuration.