### PR TITLE
enhance: batch evictable warmup by loaded size

### DIFF
--- a/include/cachinglayer/CacheSlot.h
+++ b/include/cachinglayer/CacheSlot.h
@@ -116,12 +116,10 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
                 return;
 
             case CacheWarmupPolicy::CacheWarmupPolicy_Async: {
-                auto cids = AllCellIds();
-
                 if (prefetch_pool) {
                     std::weak_ptr<CacheSlot<CellT>> weak_self = this->shared_from_this();
                     auto token = warmup_cancel_source_.getToken();
-                    prefetch_pool->add([weak_self, cids = std::move(cids), token]() {
+                    prefetch_pool->add([weak_self, token]() {
                         try {
                             auto self = weak_self.lock();
                             if (!self || token.isCancellationRequested()) {
@@ -130,7 +128,7 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
                             OpContext warmup_ctx(token);
                             // Note: caller ctx is not captured - async warmup intentionally inherits only the
                             // cancellation token, not trace context, storage usage, or other caller metadata.
-                            self->PinCellsDirect(&warmup_ctx, cids, self->warmup_loading_timeout_);
+                            self->PinWarmupCells(&warmup_ctx);
                             // If the slot is not evictable, we don't need to pin the cells anymore after warmup.
                             self->skip_pin_.store(!self->evictable_, std::memory_order_release);
                         } catch (const std::exception& e) {
@@ -144,16 +142,15 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
                 // Fallback to sync if no pool provided
                 LOG_WARN("[MCL] Async warmup requested but no prefetch pool provided, falling back to sync");
                 // TODO: Warmup is not tracked for now
-                PinCellsDirect(ctx, cids, warmup_loading_timeout_);
+                PinWarmupCells(ctx);
                 skip_pin_.store(!evictable_, std::memory_order_release);
                 return;
             }
 
             case CacheWarmupPolicy::CacheWarmupPolicy_Sync: {
-                auto cids = AllCellIds();
                 // Sync warmup (original behavior)
                 // TODO: Warmup is not tracked for now
-                PinCellsDirect(ctx, cids, warmup_loading_timeout_);
+                PinWarmupCells(ctx);
                 skip_pin_.store(!evictable_, std::memory_order_release);
                 return;
             }
@@ -370,6 +367,43 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
         std::vector<cid_t> cids(translator_->num_cells());
         std::iota(cids.begin(), cids.end(), 0);
         return cids;
+    }
+
+    [[nodiscard]] std::vector<std::vector<cid_t>>
+    LoadedSizeBatches(const std::vector<cid_t>& cids, int64_t max_loaded_bytes = kDefaultLoadedSizeBatchBytes) const {
+        std::vector<std::vector<cid_t>> batches;
+        std::vector<cid_t> batch;
+        int64_t batch_loaded_bytes = 0;
+        batch.reserve(cids.size());
+
+        for (auto cid : cids) {
+            auto loaded_size = translator_->estimated_byte_size_of_cell(cid).first;
+            auto cell_loaded_bytes = std::max(loaded_size.memory_bytes, loaded_size.file_bytes);
+            if (!batch.empty() && cell_loaded_bytes > max_loaded_bytes - batch_loaded_bytes) {
+                batches.push_back(std::move(batch));
+                batch = {};
+                batch_loaded_bytes = 0;
+            }
+            batch.push_back(cid);
+            batch_loaded_bytes += cell_loaded_bytes;
+        }
+
+        if (!batch.empty()) {
+            batches.push_back(std::move(batch));
+        }
+        return batches;
+    }
+
+    void
+    PinWarmupCells(OpContext* ctx) {
+        auto cids = AllCellIds();
+        if (!evictable_) {
+            PinCellsDirect(ctx, cids, warmup_loading_timeout_);
+            return;
+        }
+        for (const auto& batch : LoadedSizeBatches(cids)) {
+            PinCellsDirect(ctx, batch, warmup_loading_timeout_);
+        }
     }
 
     std::shared_ptr<CellAccessor<CellT>>
@@ -740,6 +774,7 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
     std::chrono::milliseconds warmup_loading_timeout_{0};
     // Bind and Unbind must use the same runtime-unit metadata even if Meta is later modified.
     std::optional<LoadingOverheadConfig> loading_overhead_config_;
+    static constexpr int64_t kDefaultLoadedSizeBatchBytes = 1LL << 30;
     std::atomic<bool> warmup_called_{false};
     std::atomic<bool> skip_pin_{false};
 };

--- a/include/cachinglayer/CacheSlot.h
+++ b/include/cachinglayer/CacheSlot.h
@@ -398,11 +398,19 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
     PinWarmupCells(OpContext* ctx) {
         auto cids = AllCellIds();
         if (!evictable_) {
-            PinCellsDirect(ctx, cids, warmup_loading_timeout_);
+            PinInternal(ctx, cids, warmup_loading_timeout_);
             return;
         }
-        for (const auto& batch : LoadedSizeBatches(cids)) {
-            PinCellsDirect(ctx, batch, warmup_loading_timeout_);
+        auto batches = LoadedSizeBatches(cids);
+        auto deadline = warmup_loading_timeout_.count() > 0 ? std::chrono::steady_clock::now() + warmup_loading_timeout_
+                                                            : std::chrono::steady_clock::time_point::max();
+        for (const auto& batch : batches) {
+            auto timeout = warmup_loading_timeout_;
+            if (timeout.count() > 0) {
+                timeout = std::max(std::chrono::milliseconds(0), std::chrono::duration_cast<std::chrono::milliseconds>(
+                                                                     deadline - std::chrono::steady_clock::now()));
+            }
+            PinInternal(ctx, batch, timeout);
         }
     }
 
@@ -774,7 +782,7 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
     std::chrono::milliseconds warmup_loading_timeout_{0};
     // Bind and Unbind must use the same runtime-unit metadata even if Meta is later modified.
     std::optional<LoadingOverheadConfig> loading_overhead_config_;
-    static constexpr int64_t kDefaultLoadedSizeBatchBytes = 1LL << 30;
+    static constexpr int64_t kDefaultLoadedSizeBatchBytes = 1LL << 29;
     std::atomic<bool> warmup_called_{false};
     std::atomic<bool> skip_pin_{false};
 };

--- a/test/test_cachinglayer/test_cache_slot.cpp
+++ b/test/test_cachinglayer/test_cache_slot.cpp
@@ -87,6 +87,9 @@ class MockTranslator : public Translator<TestCell> {
 
     std::pair<ResourceUsage, ResourceUsage>
     estimated_byte_size_of_cell(cid_t cid) const override {
+        if (auto it = loaded_size_overrides_.find(cid); it != loaded_size_overrides_.end()) {
+            return {it->second, loading_overhead_};
+        }
         auto it = cell_sizes_.find(cid);
         if (it != cell_sizes_.end()) {
             return {{it->second, 0}, loading_overhead_};
@@ -174,6 +177,11 @@ class MockTranslator : public Translator<TestCell> {
             cid_load_delay_ms_[pair.first] = pair.second;
         }
     }
+
+    void
+    SetLoadedSize(cid_t cid, ResourceUsage loaded_size) {
+        loaded_size_overrides_[cid] = loaded_size;
+    }
     void
     SetShouldThrow(bool should_throw) {
         load_should_throw_ = should_throw;
@@ -220,6 +228,7 @@ class MockTranslator : public Translator<TestCell> {
  private:
     std::unordered_map<cl_uid_t, cid_t> uid_to_cid_map_;
     std::unordered_map<cid_t, int64_t> cell_sizes_;
+    std::unordered_map<cid_t, ResourceUsage> loaded_size_overrides_;
     std::unordered_set<cid_t> cid_set_;
     const size_t num_unique_cids_;
     const std::string key_;
@@ -959,6 +968,37 @@ TEST_F(CacheSlotTest, PinAllCellsWithCancellationToken) {
     }
 }
 
+TEST(PinAllCellsTest, KeepsSingleLoadRequestAndAllCellsPinned) {
+    constexpr int64_t kMiB = 1024LL * 1024;
+    constexpr int64_t kGiB = 1024 * kMiB;
+    auto limit = ResourceUsage{10 * kGiB, 10 * kGiB};
+    auto dlist = std::make_shared<DList>(true, limit, limit, limit, EvictionConfig{10, true, 600});
+
+    std::vector<std::pair<cid_t, int64_t>> cell_sizes = {{0, 600 * kMiB}, {1, 400 * kMiB}, {2, 400 * kMiB}};
+    std::unordered_map<cl_uid_t, cid_t> uid_to_cid_map = {{0, 0}, {1, 1}, {2, 2}};
+    auto translator =
+        std::make_unique<MockTranslator>(cell_sizes, uid_to_cid_map, "pin_all_size_batched_slot", StorageType::MEMORY);
+    translator->SetLoadedSize(0, ResourceUsage{600 * kMiB, 600 * kMiB});
+    auto* translator_ptr = translator.get();
+    auto cache_slot =
+        std::make_shared<CacheSlot<TestCell>>(std::move(translator), dlist.get(), true, true, true,
+                                              std::chrono::milliseconds(100000), std::chrono::milliseconds(0));
+    auto op_ctx = std::make_unique<milvus::OpContext>();
+
+    auto accessor = SemiInlineGet(cache_slot->PinAllCells(op_ctx.get()));
+
+    ASSERT_EQ(translator_ptr->GetRequestedCids().size(), 1);
+    auto requested_cids = translator_ptr->GetRequestedCids()[0];
+    std::sort(requested_cids.begin(), requested_cids.end());
+    EXPECT_EQ(requested_cids, (std::vector<cid_t>{0, 1, 2}));
+    for (cid_t cid = 0; cid < 3; ++cid) {
+        ASSERT_NE(accessor->get_ith_cell(cid), nullptr);
+    }
+    EXPECT_FALSE(cache_slot->ManualEvictAll());
+    accessor.reset();
+    EXPECT_TRUE(cache_slot->ManualEvictAll());
+}
+
 class CacheSlotConcurrentTest : public CacheSlotTest, public ::testing::WithParamInterface<bool> {};
 
 TEST_P(CacheSlotConcurrentTest, ConcurrentAccessMultipleSlots) {
@@ -1203,11 +1243,13 @@ class MockTranslatorWithWarmup : public Translator<TestCell> {
  public:
     MockTranslatorWithWarmup(std::vector<std::pair<cid_t, int64_t>> cell_sizes,
                              std::unordered_map<cl_uid_t, cid_t> uid_to_cid_map, const std::string& key,
-                             StorageType storage_type, CacheWarmupPolicy warmup_policy)
+                             StorageType storage_type, CacheWarmupPolicy warmup_policy,
+                             ResourceUsage loading_overhead = {})
         : uid_to_cid_map_(std::move(uid_to_cid_map)),
           num_unique_cids_(cell_sizes.size()),
           key_(key),
-          meta_(storage_type, CellIdMappingMode::CUSTOMIZED, CellDataType::OTHER, warmup_policy, true) {
+          meta_(storage_type, CellIdMappingMode::CUSTOMIZED, CellDataType::OTHER, warmup_policy, true),
+          loading_overhead_(loading_overhead) {
         cid_set_.reserve(cell_sizes.size());
         cell_sizes_.reserve(cell_sizes.size());
         for (const auto& pair : cell_sizes) {
@@ -1237,11 +1279,14 @@ class MockTranslatorWithWarmup : public Translator<TestCell> {
 
     std::pair<ResourceUsage, ResourceUsage>
     estimated_byte_size_of_cell(cid_t cid) const override {
+        if (auto it = loaded_size_overrides_.find(cid); it != loaded_size_overrides_.end()) {
+            return {it->second, loading_overhead_};
+        }
         auto it = cell_sizes_.find(cid);
         if (it != cell_sizes_.end()) {
-            return {{it->second, 0}, {0, 0}};
+            return {{it->second, 0}, loading_overhead_};
         }
-        return {{1, 0}, {0, 0}};
+        return {{1, 0}, loading_overhead_};
     }
 
     int64_t
@@ -1271,6 +1316,7 @@ class MockTranslatorWithWarmup : public Translator<TestCell> {
     std::vector<std::pair<cid_t, std::unique_ptr<TestCell>>>
     get_cells(milvus::OpContext* ctx, const std::vector<cid_t>& cids) override {
         get_cells_call_count_++;
+        requested_cids_.push_back(cids);
         if (shared_call_counter_) {
             shared_call_counter_->fetch_add(1);
         }
@@ -1325,9 +1371,19 @@ class MockTranslatorWithWarmup : public Translator<TestCell> {
         }
     }
 
+    void
+    SetLoadedSize(cid_t cid, ResourceUsage loaded_size) {
+        loaded_size_overrides_[cid] = loaded_size;
+    }
+
     int
     GetCellsCallCount() const {
         return get_cells_call_count_;
+    }
+
+    const std::vector<std::vector<cid_t>>&
+    GetRequestedCids() const {
+        return requested_cids_;
     }
 
     milvus::OpContext*
@@ -1371,12 +1427,15 @@ class MockTranslatorWithWarmup : public Translator<TestCell> {
  private:
     std::unordered_map<cl_uid_t, cid_t> uid_to_cid_map_;
     std::unordered_map<cid_t, int64_t> cell_sizes_;
+    std::unordered_map<cid_t, ResourceUsage> loaded_size_overrides_;
     std::unordered_set<cid_t> cid_set_;
     const size_t num_unique_cids_;
     const std::string key_;
     Meta meta_;
+    ResourceUsage loading_overhead_;
     std::unordered_map<cid_t, int> cid_load_delay_ms_;
     std::atomic<int> get_cells_call_count_ = 0;
+    std::vector<std::vector<cid_t>> requested_cids_;
     milvus::OpContext* last_ctx_ = nullptr;
     bool last_ctx_has_trace_ = false;
     std::optional<std::string> last_trace_id_hex_;
@@ -1486,6 +1545,59 @@ TEST(WarmupTest, WarmupPassesCtxToGetCells) {
     EXPECT_EQ(translator_ptr->GetCellsCallCount(), 1);
     // Verify that the ctx was passed through to get_cells
     EXPECT_EQ(translator_ptr->GetLastCtx(), op_ctx.get());
+}
+
+TEST(WarmupTest, SyncWarmupSplitsPinCellsAtOneGiBLoadedSize) {
+    constexpr int64_t kMiB = 1024LL * 1024;
+    constexpr int64_t kGiB = 1024 * kMiB;
+    auto limit = ResourceUsage{10 * kGiB, 10 * kGiB};
+    auto dlist = std::make_shared<DList>(true, limit, limit, limit, EvictionConfig{10, true, 600});
+
+    std::vector<std::pair<cid_t, int64_t>> cell_sizes = {{0, 600 * kMiB}, {1, 400 * kMiB}, {2, 400 * kMiB}};
+    std::unordered_map<cl_uid_t, cid_t> uid_to_cid_map = {{0, 0}, {1, 1}, {2, 2}};
+    auto translator = std::make_unique<MockTranslatorWithWarmup>(
+        cell_sizes, uid_to_cid_map, "size_batched_warmup_slot", StorageType::MEMORY,
+        CacheWarmupPolicy::CacheWarmupPolicy_Sync, ResourceUsage{2 * kGiB, 0});
+    translator->SetLoadedSize(0, ResourceUsage{600 * kMiB, 600 * kMiB});
+    auto* translator_ptr = translator.get();
+
+    auto cache_slot =
+        std::make_shared<CacheSlot<TestCell>>(std::move(translator), dlist.get(), true, true, true,
+                                              std::chrono::milliseconds(100000), std::chrono::milliseconds(1000));
+
+    EXPECT_NO_THROW(cache_slot->Warmup(nullptr));
+
+    ASSERT_EQ(translator_ptr->GetRequestedCids().size(), 2);
+    auto first_batch = translator_ptr->GetRequestedCids()[0];
+    std::sort(first_batch.begin(), first_batch.end());
+    EXPECT_EQ(first_batch, (std::vector<cid_t>{0, 1}));
+    EXPECT_EQ(translator_ptr->GetRequestedCids()[1], std::vector<cid_t>{2});
+}
+
+TEST(WarmupTest, NonEvictableWarmupKeepsSingleLoadRequest) {
+    constexpr int64_t kMiB = 1024LL * 1024;
+    constexpr int64_t kGiB = 1024 * kMiB;
+    auto limit = ResourceUsage{10 * kGiB, 10 * kGiB};
+    auto dlist = std::make_shared<DList>(true, limit, limit, limit, EvictionConfig{10, true, 600});
+
+    std::vector<std::pair<cid_t, int64_t>> cell_sizes = {{0, 600 * kMiB}, {1, 400 * kMiB}, {2, 400 * kMiB}};
+    std::unordered_map<cl_uid_t, cid_t> uid_to_cid_map = {{0, 0}, {1, 1}, {2, 2}};
+    auto translator =
+        std::make_unique<MockTranslatorWithWarmup>(cell_sizes, uid_to_cid_map, "non_evictable_warmup_slot",
+                                                   StorageType::MEMORY, CacheWarmupPolicy::CacheWarmupPolicy_Sync);
+    translator->SetLoadedSize(0, ResourceUsage{600 * kMiB, 600 * kMiB});
+    auto* translator_ptr = translator.get();
+
+    auto cache_slot =
+        std::make_shared<CacheSlot<TestCell>>(std::move(translator), dlist.get(), false, true, true,
+                                              std::chrono::milliseconds(100000), std::chrono::milliseconds(1000));
+
+    EXPECT_NO_THROW(cache_slot->Warmup(nullptr));
+
+    ASSERT_EQ(translator_ptr->GetRequestedCids().size(), 1);
+    auto requested_cids = translator_ptr->GetRequestedCids()[0];
+    std::sort(requested_cids.begin(), requested_cids.end());
+    EXPECT_EQ(requested_cids, (std::vector<cid_t>{0, 1, 2}));
 }
 
 TEST(WarmupTraceContextTest, SyncWarmupPassesTraceContext) {

--- a/test/test_cachinglayer/test_cache_slot.cpp
+++ b/test/test_cachinglayer/test_cache_slot.cpp
@@ -2195,6 +2195,58 @@ TEST(WarmupTimeoutTest, PositiveTimeoutAppliesAcrossAllBatches) {
     EXPECT_EQ(translator_ptr->GetCellsCallCount(), 1);
 }
 
+TEST(WarmupTimeoutTest, SlowFirstBatchExhaustsSharedAdmissionDeadline) {
+    constexpr int64_t kMiB = 1024LL * 1024;
+    constexpr int64_t kGiB = 1024 * kMiB;
+    auto limit = ResourceUsage{kGiB, 0};
+    auto dlist = std::make_shared<DList>(true, limit, limit, limit, EvictionConfig{10, true, 600});
+
+    std::vector<std::pair<cid_t, int64_t>> cell_sizes = {{0, 500 * kMiB}, {1, 600 * kMiB}};
+    std::unordered_map<cl_uid_t, cid_t> uid_to_cid_map = {{0, 0}, {1, 1}};
+    auto translator =
+        std::make_unique<MockTranslatorWithWarmup>(cell_sizes, uid_to_cid_map, "slow_first_warmup_batch_slot",
+                                                   StorageType::MEMORY, CacheWarmupPolicy::CacheWarmupPolicy_Sync);
+    translator->SetCidLoadDelay({{0, 150}});
+    auto* translator_ptr = translator.get();
+
+    std::promise<void> first_load_completed_promise;
+    auto first_load_completed = first_load_completed_promise.get_future().share();
+    translator->SetLoadCompletedPromise(&first_load_completed_promise);
+
+    // Keep the second batch blocked until shortly after the slow first load completes. A per-batch timeout would wait
+    // and succeed, while the shared warmup deadline has already expired and must reject it immediately.
+    auto second_blocker = ResourceUsage{500 * kMiB, 0};
+    std::atomic<bool> second_blocker_scheduled = false;
+    std::atomic<bool> second_blocker_reserved = false;
+    std::thread release_second_blocker;
+    translator->SetLoadStartedCallback([&]() {
+        if (second_blocker_scheduled.exchange(true)) {
+            return;
+        }
+        auto reserve = dlist->ReserveLoadingResourceWithTimeout(second_blocker, std::chrono::milliseconds(0));
+        second_blocker_reserved.store(std::move(reserve).get());
+        if (second_blocker_reserved.load()) {
+            release_second_blocker = std::thread([dlist, second_blocker, first_load_completed]() {
+                first_load_completed.wait();
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                dlist->ReleaseLoadingResource(second_blocker);
+            });
+        }
+    });
+
+    auto cache_slot =
+        std::make_shared<CacheSlot<TestCell>>(std::move(translator), dlist.get(), true, true, true,
+                                              std::chrono::milliseconds(100000), std::chrono::milliseconds(100));
+
+    EXPECT_THROW(cache_slot->Warmup(nullptr), std::exception);
+
+    if (release_second_blocker.joinable()) {
+        release_second_blocker.join();
+    }
+    EXPECT_TRUE(second_blocker_reserved.load());
+    EXPECT_EQ(translator_ptr->GetCellsCallCount(), 1);
+}
+
 // Test that sync warmup with zero timeout (best-effort) exercises the zero-timeout
 // path in DList::ReserveLoadingResourceWithTimeout. Cell sizes fit within max capacity
 // but resources are pre-reserved so reservation fails at the zero-timeout check.

--- a/test/test_cachinglayer/test_cache_slot.cpp
+++ b/test/test_cachinglayer/test_cache_slot.cpp
@@ -1547,18 +1547,40 @@ TEST(WarmupTest, WarmupPassesCtxToGetCells) {
     EXPECT_EQ(translator_ptr->GetLastCtx(), op_ctx.get());
 }
 
-TEST(WarmupTest, SyncWarmupSplitsPinCellsAtOneGiBLoadedSize) {
+TEST(WarmupTest, WarmupUsesCidsWithoutUidRemapping) {
+    auto limit = ResourceUsage{10000, 0};
+    auto dlist = std::make_shared<DList>(true, limit, limit, limit, EvictionConfig{10, true, 600});
+
+    std::vector<std::pair<cid_t, int64_t>> cell_sizes = {{0, 100}, {1, 100}};
+    std::unordered_map<cl_uid_t, cid_t> uid_to_cid_map = {{100, 0}, {101, 1}};
+    auto translator = std::make_unique<MockTranslatorWithWarmup>(
+        cell_sizes, uid_to_cid_map, "cid_warmup_slot", StorageType::MEMORY, CacheWarmupPolicy::CacheWarmupPolicy_Sync);
+    auto* translator_ptr = translator.get();
+
+    auto cache_slot =
+        std::make_shared<CacheSlot<TestCell>>(std::move(translator), dlist.get(), true, true, true,
+                                              std::chrono::milliseconds(100000), std::chrono::milliseconds(0));
+
+    EXPECT_NO_THROW(cache_slot->Warmup(nullptr));
+
+    ASSERT_EQ(translator_ptr->GetRequestedCids().size(), 1);
+    auto requested_cids = translator_ptr->GetRequestedCids()[0];
+    std::sort(requested_cids.begin(), requested_cids.end());
+    EXPECT_EQ(requested_cids, (std::vector<cid_t>{0, 1}));
+}
+
+TEST(WarmupTest, SyncWarmupSplitsPinCellsAt512MiBLoadedSize) {
     constexpr int64_t kMiB = 1024LL * 1024;
     constexpr int64_t kGiB = 1024 * kMiB;
     auto limit = ResourceUsage{10 * kGiB, 10 * kGiB};
     auto dlist = std::make_shared<DList>(true, limit, limit, limit, EvictionConfig{10, true, 600});
 
-    std::vector<std::pair<cid_t, int64_t>> cell_sizes = {{0, 600 * kMiB}, {1, 400 * kMiB}, {2, 400 * kMiB}};
+    std::vector<std::pair<cid_t, int64_t>> cell_sizes = {{0, 300 * kMiB}, {1, 200 * kMiB}, {2, 200 * kMiB}};
     std::unordered_map<cl_uid_t, cid_t> uid_to_cid_map = {{0, 0}, {1, 1}, {2, 2}};
     auto translator = std::make_unique<MockTranslatorWithWarmup>(
         cell_sizes, uid_to_cid_map, "size_batched_warmup_slot", StorageType::MEMORY,
         CacheWarmupPolicy::CacheWarmupPolicy_Sync, ResourceUsage{2 * kGiB, 0});
-    translator->SetLoadedSize(0, ResourceUsage{600 * kMiB, 600 * kMiB});
+    translator->SetLoadedSize(0, ResourceUsage{300 * kMiB, 300 * kMiB});
     auto* translator_ptr = translator.get();
 
     auto cache_slot =
@@ -2118,6 +2140,60 @@ TEST(AsyncWarmupTest, DisabledWarmupStillWorks) {
 }
 
 // ==================== Warmup Loading Timeout Tests ====================
+
+TEST(WarmupTimeoutTest, PositiveTimeoutAppliesAcrossAllBatches) {
+    constexpr int64_t kMiB = 1024LL * 1024;
+    constexpr int64_t kGiB = 1024 * kMiB;
+    auto limit = ResourceUsage{kGiB, 0};
+    auto dlist = std::make_shared<DList>(true, limit, limit, limit, EvictionConfig{10, true, 600});
+
+    auto initial_blocker = ResourceUsage{600 * kMiB, 0};
+    auto initial_reserve = dlist->ReserveLoadingResourceWithTimeout(initial_blocker, std::chrono::milliseconds(0));
+    ASSERT_TRUE(std::move(initial_reserve).get());
+
+    std::vector<std::pair<cid_t, int64_t>> cell_sizes = {{0, 500 * kMiB}, {1, 600 * kMiB}};
+    std::unordered_map<cl_uid_t, cid_t> uid_to_cid_map = {{0, 0}, {1, 1}};
+    auto translator =
+        std::make_unique<MockTranslatorWithWarmup>(cell_sizes, uid_to_cid_map, "shared_warmup_deadline_slot",
+                                                   StorageType::MEMORY, CacheWarmupPolicy::CacheWarmupPolicy_Sync);
+    auto* translator_ptr = translator.get();
+
+    auto second_blocker = ResourceUsage{500 * kMiB, 0};
+    std::atomic<bool> second_blocker_scheduled = false;
+    std::atomic<bool> second_blocker_reserved = false;
+    std::thread release_second_blocker;
+    translator->SetLoadStartedCallback([&]() {
+        if (second_blocker_scheduled.exchange(true)) {
+            return;
+        }
+        auto reserve = dlist->ReserveLoadingResourceWithTimeout(second_blocker, std::chrono::milliseconds(0));
+        second_blocker_reserved.store(std::move(reserve).get());
+        if (second_blocker_reserved.load()) {
+            release_second_blocker = std::thread([dlist, second_blocker]() {
+                std::this_thread::sleep_for(std::chrono::milliseconds(500));
+                dlist->ReleaseLoadingResource(second_blocker);
+            });
+        }
+    });
+
+    auto cache_slot =
+        std::make_shared<CacheSlot<TestCell>>(std::move(translator), dlist.get(), true, true, true,
+                                              std::chrono::milliseconds(100000), std::chrono::milliseconds(600));
+
+    std::thread release_initial_blocker([dlist, initial_blocker]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        dlist->ReleaseLoadingResource(initial_blocker);
+    });
+
+    EXPECT_THROW(cache_slot->Warmup(nullptr), std::exception);
+
+    release_initial_blocker.join();
+    if (release_second_blocker.joinable()) {
+        release_second_blocker.join();
+    }
+    EXPECT_TRUE(second_blocker_reserved.load());
+    EXPECT_EQ(translator_ptr->GetCellsCallCount(), 1);
+}
 
 // Test that sync warmup with zero timeout (best-effort) exercises the zero-timeout
 // path in DList::ReserveLoadingResourceWithTimeout. Cell sizes fit within max capacity


### PR DESCRIPTION
- split evictable cache warmup into batches capped at 1 GiB of estimated loaded size
- calculate each cell's batch contribution as the maximum of `memory_bytes` and `file_bytes`
- keep non-evictable warmup and `PinAllCells()` as single loading requests