### PR TITLE
fix: log cache cell unaccessed survival time in seconds

### DIFF
--- a/src/cachinglayer/Manager.cpp
+++ b/src/cachinglayer/Manager.cpp
@@ -68,7 +68,7 @@ Manager::ConfigureTieredStorage(CacheWarmupPolicies warmup_policies, CacheLimit 
             "background eviction enabled: {}, eviction interval: {} ms, "
             "physical memory max ratio: {}, max disk usage percentage: {}, "
             "loading resource factor: {}, cache cell unaccessed survival time: "
-            "{} ms, warmup policies: {}",
+            "{} s, warmup policies: {}",
             FormatBytes(low_watermark.memory_bytes), FormatBytes(high_watermark.memory_bytes),
             FormatBytes(max.memory_bytes), FormatBytes(low_watermark.file_bytes),
             FormatBytes(high_watermark.file_bytes), FormatBytes(max.file_bytes),


### PR DESCRIPTION
## What

The Tiered Storage startup log prints `cache_cell_unaccessed_survival_time` with an `ms` unit suffix, but the field is `std::chrono::seconds`, so `.count()` yields whole seconds. This changes the suffix to `s`.

## Why

`queryNode.segcore.tieredStorage.cacheTtl` is documented on the Milvus side as *"Time in seconds after which an unaccessed cache cell will be evicted"*, and the value flows through unconverted:

- `internal/util/initcore/init_core.go` passes `GetAsInt64()` straight to `ConfigureTieredStorage`
- `segcore_init_c.cpp` forwards it into `EvictionConfig`
- `include/cachinglayer/Utils.h` stores it as `std::chrono::seconds(cache_cell_unaccessed_survival_time)`

So the value really is seconds end to end. Only the log message disagrees. Configuring `cacheTtl: 86400` currently prints

```
cache cell unaccessed survival time: 86400 ms
```

which reads as 86.4 seconds and makes the setting look like it is off by 1000x. That is a misleading signal precisely when someone is checking whether their TTL took effect — the log is the only place this value is observable.

The two neighbouring entries in the same log line are genuinely millisecond-typed and correctly labelled:

| field | type | current label |
| --- | --- | --- |
| `cache_touch_window` | `std::chrono::milliseconds` | `ms` (correct) |
| `eviction_interval` | `std::chrono::milliseconds` | `ms` (correct) |
| `cache_cell_unaccessed_survival_time` | `std::chrono::seconds` | `ms` (wrong) |

The naming convention on the Milvus config side points the same way: `cacheTouchWindowMs`, `evictionIntervalMs` and `loadingTimeoutMs` all carry an explicit `Ms` suffix, while `cacheTtl` deliberately does not.

## Change

One-character fix to the format string in `Manager::ConfigureTieredStorage`. Each entry keeps printing its raw `.count()` labelled with the unit of its own type.

## Impact

Log text only. Runtime behaviour is unchanged: `DList::tryEvict` computes `steady_clock::now() - eviction_config_.cache_cell_unaccessed_survival_time`, and `std::chrono` converts the duration correctly regardless of how it is printed. Eviction already honours the configured value as seconds, consistent with the verification on milvus-io/milvus#44542 (a `cacheTtl` of one hour began evicting between 1h and 1h + `evictionIntervalMs`).

Related for context, not fixed here: milvus-io/milvus#44542 was a separate `cacheTtl` defect (TTL eviction not triggering at all), fixed by #39.
