### PR TITLE
enhance: publish a conan package when a commit lands on master

### DIFF
--- a/.github/workflows/notify-conanfiles.yaml
+++ b/.github/workflows/notify-conanfiles.yaml
@@ -1,18 +1,33 @@
 name: Notify conanfiles
 
-run-name: notify conanfiles for ${{ github.ref_name }}
+run-name: >-
+  notify conanfiles for
+  ${{ github.ref_type == 'tag' && github.ref_name || format('{0}@{1}', github.ref_name, github.sha) }}
 
 on:
   push:
+    branches:
+      - master
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
 
+# contents: write is needed to create the snapshot tag for a master commit.
+# The downstream recipe sources https://github.com/<repo>/archive/refs/tags/<tag>.tar.gz,
+# so the tag has to be a real ref -- a synthetic name would 404 when the
+# conanfiles job computes the source sha256.
 permissions:
-  contents: read
+  contents: write
+
+env:
+  # Base version for auto-created snapshot tags. Matches the v1.0.0-<short sha>
+  # convention every published package already follows.
+  VERSION_BASE: '1.0.0'
 
 jobs:
-  # When a new release tag is pushed to milvus-common, send a repository_dispatch event
-  # to the conanfiles repo to trigger the release of the corresponding Conan package.
+  # A commit on master (or a hand-pushed release tag) is turned into a tag and a
+  # repository_dispatch event to the conanfiles repo, which opens the recipe PR
+  # that publishes the corresponding Conan package.
   dispatch:
     name: send milvus-common release dispatch
     if: github.repository == 'zilliztech/milvus-common'
@@ -23,10 +38,43 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Resolve release tag
+        id: resolve
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          # A release tag pushed by hand keeps its exact name (previous behaviour).
+          if [ "$REF_TYPE" = "tag" ]; then
+            echo "tag=${REF_NAME}" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # A commit that landed on master (or a manual run) publishes a snapshot
+          # of itself, so downstream repos can bump their pin as soon as the PR
+          # is merged instead of waiting for someone to remember to tag.
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          TAG="v${VERSION_BASE}-${SHORT_SHA}"
+
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag ${TAG} already exists; reusing it"
+          else
+            git tag "$TAG" "$(git rev-parse HEAD)"
+            git push origin "refs/tags/${TAG}"
+            echo "Created tag ${TAG}"
+          fi
+
+          # NOTE: a tag pushed with GITHUB_TOKEN does not start another workflow
+          # run, which is why this job dispatches below instead of relying on the
+          # tag trigger to fire a second time.
+          echo "tag=${TAG}" >>"$GITHUB_OUTPUT"
+
       - name: Send repository_dispatch to conanfiles
         env:
           GH_TOKEN: ${{ secrets.CONANFILES_DISPATCH_TOKEN }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ steps.resolve.outputs.tag }}
           SOURCE_REPO: zilliztech/milvus-common
         run: |
           set -euo pipefail


### PR DESCRIPTION
Publishing a Conan package currently requires a maintainer to remember to push a `v1.0.0-<sha>` tag after the PR is merged. Until that happens the change is unconsumable downstream, and nothing signals that a step is missing — milvus-io/milvus#50768 has been blocked on exactly this since #112 was merged, failing three repos away with `'RegisterUntypedCgoExceptionObserver' is not a member of 'milvus'`.

This makes a commit landing on `master` publish a snapshot of itself.

### What changed

- `push: branches: [master]` — a merged PR now publishes without a second manual step.
- `workflow_dispatch` — a failed run can be replayed from the Actions page, no tag push required.
- A "Resolve release tag" step that **creates** `v<VERSION_BASE>-<short sha>` for the master commit, then hands it to the existing dispatch step untouched.
- `permissions: contents: write`, needed to push that tag.

A hand-pushed `v*.*.*` tag keeps its exact previous behaviour: the resolve step passes it straight through.

### Why the tag is created rather than bypassed

The recipe generated downstream sources the GitHub tag archive and hashes it:

```python
# conanfiles/scripts/update-recipe-from-dispatch.py
"url": "https://github.com/{source_repo}/archive/refs/tags/{tag}.tar.gz"
...
sha256 = download_sha256(url)
```

So the tag has to resolve to a real ref — sending a branch name or a synthetic version through `client_payload[tag]` would 404 at that download. Creating the tag keeps the "published package ⟺ tag exists" invariant and needs **no change in `milvus-io/conanfiles`**.

`VERSION_BASE` defaults to `1.0.0`, matching the convention all 20 existing tags already follow.

### Notes

- **Idempotent.** If the tag already exists (re-run, or a tag pushed by hand for the same commit) the step reuses it. The downstream job is also a no-op when the recipe version is already present, so a duplicate dispatch does not open a second PR.
- **No self-trigger loop.** A tag pushed with `GITHUB_TOKEN` does not start another workflow run, so this job dispatches directly rather than relying on the tag trigger firing again. There is a comment in the file so the behaviour is not "fixed" later by someone expecting a second run.
- **Volume.** `master` takes ~8 commits/month (25 in the last 90 days), so ~8 extra recipe PRs and package versions per month.
- Consumers all pin explicitly, so extra published versions never upgrade anyone implicitly.

### If you would rather keep publishing selective

Dropping the `branches: [master]` trigger leaves `workflow_dispatch`, which still removes the "must know the tag convention and hold push rights" part of the problem. Happy to trim it to that variant.

### Verification

- `yaml.safe_load` parses the workflow; triggers, permissions and step list are as intended.
- Both `run` blocks pass `bash -n`.
- Dispatch step body is byte-identical to the current one except for reading `TAG` from the resolve step's output.

Full analysis of the dependency chain and the alternatives considered: this was found while unblocking milvus-io/milvus#50768.

issue: #117
