### PR TITLE
fix: [2.6] log cache cell unaccessed survival time in seconds

### DIFF
--- a/src/cachinglayer/Manager.cpp
+++ b/src/cachinglayer/Manager.cpp
@@ -67,7 +67,7 @@ Manager::ConfigureTieredStorage(CacheWarmupPolicies warmup_policies, CacheLimit 
             "background eviction enabled: {}, eviction interval: {} ms, "
             "physical memory max ratio: {}, max disk usage percentage: {}, "
             "loading resource factor: {}, cache cell unaccessed survival time: "
-            "{} ms, warmup policies: {}",
+            "{} s, warmup policies: {}",
             FormatBytes(low_watermark.memory_bytes), FormatBytes(high_watermark.memory_bytes),
             FormatBytes(max.memory_bytes), FormatBytes(low_watermark.file_bytes),
             FormatBytes(high_watermark.file_bytes), FormatBytes(max.file_bytes),


### PR DESCRIPTION
## What

Backport #116 to the `2.6` branch. Correct the Tiered Storage startup log unit for `cache_cell_unaccessed_survival_time` from `ms` to `s`, matching its `std::chrono::seconds` type.

## Impact

Log text only. Runtime behavior is unchanged.

## Testing

Not run locally; this is a one-character log label change.